### PR TITLE
fix(setup_edgenode): lose last " when replace --kubeconfig in 10-kubeadm.conf

### DIFF
--- a/config/yurtctl-servant/setup_edgenode
+++ b/config/yurtctl-servant/setup_edgenode
@@ -164,10 +164,10 @@ reset_kubelet() {
     if [ -f $BOOTSTRAP_KUBELET_CONF ]; then
         # /etc/kubernetes/bootstrap-kubelet.config exist, keep the 
         # --bootstrap-kubeconfig option
-        sed -i "s|--kubeconfig=.*|--kubeconfig=$OPENYURT_DIR\/kubelet.conf|g" $KUBELET_SVC
+        sed -i "s|--kubeconfig=.*|--kubeconfig=$OPENYURT_DIR\/kubelet.conf\"|g" $KUBELET_SVC
     else
         sed -i "s/--bootstrap.*bootstrap-kubelet.conf//g;
-        s|--kubeconfig=.*|--kubeconfig=$OPENYURT_DIR\/kubelet.conf|g" $KUBELET_SVC
+        s|--kubeconfig=.*|--kubeconfig=$OPENYURT_DIR\/kubelet.conf\"|g" $KUBELET_SVC
     fi
     log "revised the kubelet.service drop-in file"
     # reset the kubelete.service
@@ -190,7 +190,7 @@ revert_kubelet() {
     # remove openyurt's kubelet.conf if exist
     [ -f $OPENYURT_DIR/kubelet.conf ] && rm $OPENYURT_DIR/kubelet.conf
     # revise the kubelet.service drop-in
-    sed -i "s|--kubeconfig=.*|--kubeconfig=$KUBELET_CONF|g;" $KUBELET_SVC
+    sed -i "s|--kubeconfig=.*|--kubeconfig=$KUBELET_CONF\"|g;" $KUBELET_SVC
     log "revised the kubelet.service drop-in file back to the default"
     # reset the kubelete.service
     systemctl daemon-reload


### PR DESCRIPTION
do not think the last " when setup_edgenode replace --kubeconfig。when run setup_edgenode,the user get 10-kubeadm.conf that do not have Incorrect file format。 