### PR TITLE
Fix yurthub tests

### DIFF
--- a/pkg/yurthub/healthchecker/health_checker_test.go
+++ b/pkg/yurthub/healthchecker/health_checker_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestHealthyCheckerWithHealthyServers(t *testing.T) {
 	servers := []string{
-		"127.0.0.1:8080",
-		"127.0.0.1:8081",
-		"127.0.0.1:8082",
+		"127.0.0.1:18080",
+		"127.0.0.1:18081",
+		"127.0.0.1:18082",
 	}
 
 	// start local http server
@@ -77,9 +77,9 @@ func TestHealthyCheckerWithHealthyServers(t *testing.T) {
 
 func TestHealthyCheckerWithUnhealthyServers(t *testing.T) {
 	servers := []string{
-		"127.0.0.1:8080",
-		"127.0.0.1:8081",
-		"127.0.0.1:8082",
+		"127.0.0.1:18080",
+		"127.0.0.1:18081",
+		"127.0.0.1:18082",
 	}
 
 	// start local http server
@@ -137,7 +137,7 @@ func TestHealthyCheckerWithUnhealthyServers(t *testing.T) {
 
 func TestHealthyCheckerFromHealthyToUnhealthy(t *testing.T) {
 	servers := []string{
-		"127.0.0.1:8080",
+		"127.0.0.1:18080",
 	}
 
 	reqCnt := 0
@@ -217,7 +217,7 @@ func TestHealthyCheckerFromHealthyToUnhealthy(t *testing.T) {
 
 func TestHealthyCheckerFromUnHealthyToHealthy(t *testing.T) {
 	servers := []string{
-		"127.0.0.1:8080",
+		"127.0.0.1:18080",
 	}
 
 	reqCnt := 0

--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -24,16 +24,19 @@ type diskStorage struct {
 }
 
 // NewDiskStorage creates a storage.Store for caching data into local disk
-func NewDiskStorage() (storage.Store, error) {
-	if _, err := os.Stat(cacheBaseDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(cacheBaseDir, 0755); err != nil {
+func NewDiskStorage(dir string) (storage.Store, error) {
+	if dir == "" {
+		dir = cacheBaseDir
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
 			return nil, err
 		}
 	}
 
 	ds := &diskStorage{
 		keyPendingStatus: make(map[string]struct{}, 0),
-		baseDir:          cacheBaseDir,
+		baseDir:          dir,
 	}
 
 	err := ds.Recover("")
@@ -54,7 +57,7 @@ func (ds *diskStorage) Create(key string, contents []byte) error {
 	}
 	defer ds.unLockKey(key)
 
-	absKey := filepath.Join(cacheBaseDir, key)
+	absKey := filepath.Join(ds.baseDir, key)
 	if info, err := os.Stat(absKey); err != nil {
 		if os.IsNotExist(err) {
 			dir, _ := filepath.Split(absKey)
@@ -130,7 +133,7 @@ func (ds *diskStorage) delete(key string) error {
 	}
 	defer ds.unLockKey(key)
 
-	absKey := filepath.Join(cacheBaseDir, key)
+	absKey := filepath.Join(ds.baseDir, key)
 	info, err := os.Stat(absKey)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -148,7 +151,7 @@ func (ds *diskStorage) delete(key string) error {
 
 // Get get contents from the file that specified by key
 func (ds *diskStorage) Get(key string) ([]byte, error) {
-	return ds.get(filepath.Join(cacheBaseDir, key))
+	return ds.get(filepath.Join(ds.baseDir, key))
 }
 
 func (ds *diskStorage) get(path string) ([]byte, error) {
@@ -156,7 +159,7 @@ func (ds *diskStorage) get(path string) ([]byte, error) {
 		return nil, nil
 	}
 
-	key := strings.TrimPrefix(path, cacheBaseDir)
+	key := strings.TrimPrefix(path, ds.baseDir)
 	if !ds.lockKey(key) {
 		return nil, storage.ErrStorageAccessConflict
 	}
@@ -183,7 +186,7 @@ func (ds *diskStorage) get(path string) ([]byte, error) {
 // ListKeys list all of keys for files
 func (ds *diskStorage) ListKeys(key string) ([]string, error) {
 	keys := make([]string, 0)
-	absPath := filepath.Join(cacheBaseDir, key)
+	absPath := filepath.Join(ds.baseDir, key)
 	if info, err := os.Stat(absPath); err != nil {
 		if os.IsNotExist(err) {
 			return keys, nil
@@ -198,7 +201,7 @@ func (ds *diskStorage) ListKeys(key string) ([]string, error) {
 			if info.Mode().IsRegular() {
 				_, file := filepath.Split(path)
 				if !strings.HasPrefix(file, tmpPrefix) {
-					keys = append(keys, strings.TrimPrefix(path, cacheBaseDir))
+					keys = append(keys, strings.TrimPrefix(path, ds.baseDir))
 				}
 			}
 
@@ -221,7 +224,7 @@ func (ds *diskStorage) List(key string) ([][]byte, error) {
 	}
 
 	bb := make([][]byte, 0)
-	absKey := filepath.Join(cacheBaseDir, key)
+	absKey := filepath.Join(ds.baseDir, key)
 	info, err := os.Stat(absKey)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -285,8 +288,8 @@ func (ds *diskStorage) Update(key string, contents []byte) error {
 		return err
 	}
 
-	tmpPath := filepath.Join(cacheBaseDir, tmpKey)
-	absKey := filepath.Join(cacheBaseDir, key)
+	tmpPath := filepath.Join(ds.baseDir, tmpKey)
+	absKey := filepath.Join(ds.baseDir, key)
 	info, err := os.Stat(absKey)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -305,7 +308,7 @@ func (ds *diskStorage) Update(key string, contents []byte) error {
 
 // Recover recover storage error
 func (ds *diskStorage) Recover(key string) error {
-	dir := filepath.Join(cacheBaseDir, key)
+	dir := filepath.Join(ds.baseDir, key)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -314,9 +317,9 @@ func (ds *diskStorage) Recover(key string) error {
 		if info.Mode().IsRegular() {
 			_, file := filepath.Split(path)
 			if strings.HasPrefix(file, tmpPrefix) {
-				tmpKey := strings.TrimPrefix(path, cacheBaseDir)
+				tmpKey := strings.TrimPrefix(path, ds.baseDir)
 				key := getKey(tmpKey)
-				keyPath := filepath.Join(cacheBaseDir, key)
+				keyPath := filepath.Join(ds.baseDir, key)
 				if !ds.lockKey(key) {
 					return nil
 				}

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 var (
+	testDir = "/tmp/cache/"
 	tempDir = "kubelet/default/pods"
 	tempKey = "kubelet/default/pods/test-pod"
 )
 
 func TestCreate(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -25,7 +26,7 @@ func TestCreate(t *testing.T) {
 		t.Errorf("Got error %v, wanted successful create %s", err, tempKey)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
@@ -39,13 +40,13 @@ func TestCreate(t *testing.T) {
 		t.Errorf("Wanted string: test-pod but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestCreateFileExist(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -60,7 +61,7 @@ func TestCreateFileExist(t *testing.T) {
 		t.Errorf("Got error %v, wanted successful create %s witch contents test-pod2", err, tempKey)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
@@ -74,18 +75,18 @@ func TestCreateFileExist(t *testing.T) {
 		t.Errorf("Wanted string: test-pod2 but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestCreateDirExist(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	dir, _ := filepath.Split(createdFile)
 	if err = os.MkdirAll(dir, 0755); err != nil {
 		t.Errorf("Got error %v, unable make dir %s", err, dir)
@@ -109,13 +110,13 @@ func TestCreateDirExist(t *testing.T) {
 		t.Errorf("Wanted string: test-pod but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestDelete(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -125,7 +126,7 @@ func TestDelete(t *testing.T) {
 		t.Errorf("Got error %v, wanted successful create %s", err, tempKey)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
@@ -141,30 +142,30 @@ func TestDelete(t *testing.T) {
 		t.Errorf("want %q is deleted, but it still exist", createdFile)
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestDeleteFileNotExist(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	err = s.Delete(tempKey)
 	if err != nil {
 		t.Errorf("Got error %v, delete not exist file(%q) returned error", err, createdFile)
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestDeleteDir(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -179,20 +180,20 @@ func TestDeleteDir(t *testing.T) {
 		t.Errorf("Got error %v, unable delete dir key %q", err, tempDir)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
 		t.Errorf("Got %q not a regular file", createdFile)
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestGet(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -209,13 +210,13 @@ func TestGet(t *testing.T) {
 		t.Errorf("Wanted string: test-pod but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestGetFileNotExist(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -227,13 +228,13 @@ func TestGetFileNotExist(t *testing.T) {
 		t.Errorf("Wanted empty string got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestGetNotRegularFile(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -248,13 +249,13 @@ func TestGetNotRegularFile(t *testing.T) {
 		t.Errorf("Got not error for dir key %q", tempDir)
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestListKeys(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -286,17 +287,17 @@ func TestListKeys(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("key %s is not found by list keys", key)
+			t.Errorf("key %s is not found by list keys %v", key, keys)
 		}
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestListKeysForEmptyDir(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -310,13 +311,13 @@ func TestListKeysForEmptyDir(t *testing.T) {
 		t.Errorf("expect 0 key, but got %d keys", len(keys))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestListKeysForRegularFile(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -339,13 +340,13 @@ func TestListKeysForRegularFile(t *testing.T) {
 		t.Errorf("listKeys: expect %s key, but got %s key", tempKey, keys[0])
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestList(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -381,13 +382,13 @@ func TestList(t *testing.T) {
 		}
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestListEmptyDir(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -401,13 +402,13 @@ func TestListEmptyDir(t *testing.T) {
 		t.Errorf("expect no contents, but got %d number of contents", len(contents))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestListSpecifiedFile(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -430,13 +431,13 @@ func TestListSpecifiedFile(t *testing.T) {
 		t.Errorf("expect content: test-pod, but got content: %s", contents[0])
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestUpdate(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -451,7 +452,7 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("Got error %v, unable update key %s", err, tempKey)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
@@ -465,13 +466,13 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("Wanted string: test-pod1 but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }
 
 func TestUpdateEmptyString(t *testing.T) {
-	s, err := NewDiskStorage()
+	s, err := NewDiskStorage(testDir)
 	if err != nil {
 		t.Fatalf("unable to new disk storage, %v", err)
 	}
@@ -486,7 +487,7 @@ func TestUpdateEmptyString(t *testing.T) {
 		t.Errorf("Got error %v, unable update key %s", err, tempKey)
 	}
 
-	createdFile := filepath.Join(cacheBaseDir, tempKey)
+	createdFile := filepath.Join(testDir, tempKey)
 	if fi, err := os.Stat(createdFile); err != nil {
 		t.Errorf("Got error %v, wanted file %q to be there", err, createdFile)
 	} else if !fi.Mode().IsRegular() {
@@ -500,7 +501,7 @@ func TestUpdateEmptyString(t *testing.T) {
 		t.Errorf("Wanted string: empty string but got %s", string(b))
 	}
 
-	if err = os.RemoveAll(cacheBaseDir); err != nil {
-		t.Errorf("Got error %v, unable remove path %s", err, cacheBaseDir)
+	if err = os.RemoveAll(testDir); err != nil {
+		t.Errorf("Got error %v, unable remove path %s", err, testDir)
 	}
 }

--- a/pkg/yurthub/storage/factory/factory.go
+++ b/pkg/yurthub/storage/factory/factory.go
@@ -7,6 +7,5 @@ import (
 
 // CreateStorage create a storage.Store for backend storage
 func CreateStorage() (storage.Store, error) {
-
-	return disk.NewDiskStorage()
+	return disk.NewDiskStorage("")
 }


### PR DESCRIPTION
This change fixes health_checker_test and storage_test. 

The ports 8080/8081/8082 can easily be occupied by other processes. This change picks ports that are less likely to be occupied.

"/etc/kubernetes/cache" directory often needs permission to create. This change creates test directory in "/tmp/cache/". 