### PR TITLE
set the server-addr before deploying the yurthub

### DIFF
--- a/config/setup/yurthub.yaml
+++ b/config/setup/yurthub.yaml
@@ -33,7 +33,7 @@ spec:
     command:
     - yurthub 
     - --v=2
-    - --server-addr=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT_HTTPS)
+    - --server-addr=https://__kubernetes_service_host__:__kubernetes_service_port_https__
     - --node-name=$(NODE_NAME)
     livenessProbe:
       httpGet:

--- a/config/yurtctl-servant/setup_edgenode
+++ b/config/yurtctl-servant/setup_edgenode
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # This script can not be executed directly, it is baked in the 
-# openyurt/yurtctl-servant, before exeuction, context value (i.e., {{.VARIABLE}})
+# openyurt/yurtctl-servant, before exeuction, context value (i.e., __variable__)
 # need to be replaced based on the environment variables set in the pod, 
 # and will be executed as a subprogram of the nsenter command.
 
@@ -56,7 +56,7 @@ spec:
     command:
     - yurthub
     - --v=2
-    - --server-addr=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT_HTTPS)
+    - --server-addr=https://__kubernetes_service_host__:__kubernetes_service_port_https__
     - --node-name=$(NODE_NAME)
     livenessProbe:
       httpGet:

--- a/docs/tutorial/manually-setup.md
+++ b/docs/tutorial/manually-setup.md
@@ -58,9 +58,14 @@ restarted automatically.
 
 ## Setup Yurthub
 
-After the Yurt controller manager is up and running, we will setup Yurthub as the static pod by typing the following command,
+After the Yurt controller manager is up and running, we will setup Yurthub as the static pod. Before proceeding, 
+please get the apiserver's address (i.e., ip:port), which will be used to replace the place holder in the template 
+file `config/setup/yurthub.yaml`. In the following command, we assume that the address of the apiserver is 1.2.3.4:5678
 ```bash
-$ cat config/setup/yurthub.yaml | sed 's|__pki_path__|/etc/kubernetes/pki|' > /tmp/yurthub-ack.yaml &&
+$ cat config/setup/yurthub.yaml | 
+sed 's|__pki_path__|/etc/kubernetes/pki|;
+s|__kubernetes_service_host__|1.2.3.4|;
+s|__kubernetes_service_port_https__|5678|' > /tmp/yurthub-ack.yaml &&
 scp -i <yourt-ssh-identity-file> /tmp/yurthub-ack.yaml root@us-west-1.192.168.0.88:/etc/kubernetes/manifests
 ```
 and the Yurthub will be ready in minutes.

--- a/pkg/yurthub/README.md
+++ b/pkg/yurthub/README.md
@@ -52,8 +52,4 @@ please do the following:
 
 ## Trouble Shooting
 
-1. When you want to test the autonomy function of edge node by rebooting the edge node. The yurthub may not initiate properly.
-
-   This is because the startup parameters of yurthub are configured to read the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT_HTTPS`, which is initialized by kubelet after connecting to apiserver.  However, kubelet can't talk to the apiserver, as the yurthub has not started yet. So you may need to temporarily modify the startup parameters of yurthub `--server-addr=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT_HTTPS)` to `--server-addr=https://{apiserver-service-cluster-ip}:{apiserver-service-cluster-port}` or `--server-addr=https://{master-node-ip}:{apiserver-port}` in `yurthub.yaml`. 
-  
-   **`apiserver-service-cluster-ip` and `apiserver-service-cluster-port` can be found by `kubectl get svc/kubernetes -n default`. Also, please make sure your kube-proxy is running properly**
+1. When you want to test the autonomy function of edge node by rebooting the edge node. The yurthub may not initiate properly. (**NOTE: this issue has been fixed by PR [#49](https://github.com/alibaba/openyurt/pull/49)**)


### PR DESCRIPTION
Instead of getting the apiserver's address from the env during the runtime, let servant pod set it before deploying the yurthub.

fix #47 