### PR TITLE
Remove annotation: "node.beta.alibabacloud.com/autonomy=true" when re…

### DIFF
--- a/pkg/yurtctl/cmd/revert/revert.go
+++ b/pkg/yurtctl/cmd/revert/revert.go
@@ -108,6 +108,11 @@ func (ro *RevertOptions) RunRevert() (err error) {
 		isEdgeNode, ok := node.Labels[constants.LabelEdgeWorker]
 		if ok && isEdgeNode == "true" {
 			edgeNodeNames = append(edgeNodeNames, node.GetName())
+
+			_, found := node.Annotations[constants.AnnotationAutonomy]
+			if found {
+				delete(node.Annotations, constants.AnnotationAutonomy)
+			}
 		}
 		if ok {
 			delete(node.Labels, constants.LabelEdgeWorker)


### PR DESCRIPTION
Fix issue: #53 

`revert` should remove annotation: "node.beta.alibabacloud.com/autonomy=true" on the edge nodes added by `yurtctl markautonomous`.