### PR TITLE
Refactor: implement the HandlerWrapper and decouple server/agent interface from implementation 

### DIFF
--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -54,7 +54,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
-        alibabacloud.com/edge-enable-reverseTunnel-client: "true"
+        openyurt.io/edge-enable-reverseTunnel-client: "true"
       containers:
       - command:
         - yurt-tunnel-agent

--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -115,7 +115,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
-        alibabacloud.com/is-edge-worker: "false"
+        openyurt.io/is-edge-worker: "false"
       containers:
       - name: yurt-tunnel-server
         image: openyurt/yurt-tunnel-server:latest

--- a/pkg/yurttunnel/agent/anpagent.go
+++ b/pkg/yurttunnel/agent/anpagent.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"crypto/tls"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"k8s.io/klog"
+	anpagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+)
+
+// anpTunnelAgent implements the TunnelAgent using the
+// apiserver-network-proxy package
+type anpTunnelAgent struct {
+	tlsCfg           *tls.Config
+	tunnelServerAddr string
+	nodeName         string
+}
+
+var _ TunnelAgent = &anpTunnelAgent{}
+
+// RunAgent runs the yurttunnel-agent which will try to connect yurttunnel-server
+func (ata *anpTunnelAgent) Run(stopChan <-chan struct{}) {
+	dialOption := grpc.WithTransportCredentials(credentials.NewTLS(ata.tlsCfg))
+	cc := &anpagent.ClientSetConfig{
+		Address:                 ata.tunnelServerAddr,
+		AgentID:                 ata.nodeName,
+		SyncInterval:            5 * time.Second,
+		ProbeInterval:           5 * time.Second,
+		ReconnectInterval:       5 * time.Second,
+		DialOption:              dialOption,
+		ServiceAccountTokenPath: "",
+	}
+
+	cs := cc.NewAgentClientSet(stopChan)
+	cs.Serve()
+	klog.Infof("start serving grpc request redirected from yurttunel-server: %s",
+		ata.tunnelServerAddr)
+}

--- a/pkg/yurttunnel/agent/cmd.go
+++ b/pkg/yurttunnel/agent/cmd.go
@@ -150,7 +150,8 @@ func (o *YurttunnelAgentOptions) run(stopCh <-chan struct{}) error {
 	}
 
 	// 4. start the yurttunnel-agent
-	RunAgent(tlsCfg, tunnelServerAddr, o.nodeName, stopCh)
+	ta := NewTunnelAgent(tlsCfg, tunnelServerAddr, o.nodeName)
+	ta.Run(stopCh)
 
 	<-stopCh
 	return nil

--- a/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
+++ b/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlerwrapper
+
+import (
+	"net/http"
+)
+
+// Middleware takes in one Handler and wrap it within another
+type Middleware func(http.Handler) http.Handler
+
+var Middlewares []Middleware

--- a/pkg/yurttunnel/handlerwrapper/printreqinfo/printreqinfo.go
+++ b/pkg/yurttunnel/handlerwrapper/printreqinfo/printreqinfo.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printreqinfo
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/klog"
+
+	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
+)
+
+func init() {
+	hw.Middlewares = append(hw.Middlewares, PrintReqInfoMiddleware)
+}
+
+// PrintReqInfoMiddleware prints request information when start/stop
+// handling the request
+var PrintReqInfoMiddleware = func(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		klog.V(4).Infof("start handling request %s %s, from %s to %s",
+			req.Method, req.URL.String(), req.Host, req.RemoteAddr)
+		start := time.Now()
+		handler.ServeHTTP(w, req)
+		klog.V(4).Infof("stop handling request %s %s, request handling lasts %v",
+			req.Method, req.URL.String(), time.Now().Sub(start))
+	})
+}

--- a/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
+++ b/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wraphandler
+
+import (
+	"net/http"
+
+	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
+
+	// followings are the middleware packages
+	//
+	// NOTE the package importing order decide the order in which
+	// the middleware will be called
+	//
+	// e.g. there are two middleware mw1 and mw2
+	// if the packages are imported in the following order,
+	//
+	// _ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/mw2"
+	// _ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/mw1"
+	//
+	// then the middleware m2 will be called before the mw1
+
+	_ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/printreqinfo"
+)
+
+// WrapWrapHandler wraps the coreHandler with handlerwrapper.Middlewares
+func WrapHandler(coreHandler http.Handler) http.Handler {
+	handler := coreHandler
+	if len(hw.Middlewares) == 0 {
+		return handler
+	}
+	for i := len(hw.Middlewares) - 1; i >= 0; i-- {
+		handler = hw.Middlewares[i](handler)
+	}
+	return handler
+}

--- a/pkg/yurttunnel/server/anpserver.go
+++ b/pkg/yurttunnel/server/anpserver.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"k8s.io/klog"
+	anpserver "sigs.k8s.io/apiserver-network-proxy/pkg/server"
+	anpagent "sigs.k8s.io/apiserver-network-proxy/proto/agent"
+
+	wh "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/wraphandler"
+)
+
+// anpTunnelServer implements the TunnelServer interface using the
+// apiserver-network-proxy package
+type anpTunnelServer struct {
+	egressSelectorEnabled    bool
+	interceptorServerUDSFile string
+	serverMasterAddr         string
+	serverMasterInsecureAddr string
+	serverAgentAddr          string
+	tlsCfg                   *tls.Config
+}
+
+var _ TunnelServer = &anpTunnelServer{}
+
+// Run runs the yurttunnel-server
+func (ats *anpTunnelServer) Run() error {
+	proxyServer := anpserver.NewProxyServer(uuid.New().String(), 1,
+		&anpserver.AgentTokenAuthenticationOptions{})
+	// 1. start the proxier
+	proxierErr := runProxier(
+		&anpserver.Tunnel{Server: proxyServer},
+		ats.egressSelectorEnabled,
+		ats.interceptorServerUDSFile,
+		ats.tlsCfg)
+	if proxierErr != nil {
+		return fmt.Errorf("fail to run the proxier: %s", proxierErr)
+	}
+
+	wrappedHandler := wh.WrapHandler(
+		&RequestInterceptor{
+			UDSSockFile: ats.interceptorServerUDSFile,
+			TLSConfig:   ats.tlsCfg,
+		},
+	)
+
+	// 2. start the master server
+	masterServerErr := runMasterServer(
+		wrappedHandler,
+		ats.egressSelectorEnabled,
+		ats.serverMasterAddr,
+		ats.serverMasterInsecureAddr,
+		ats.tlsCfg)
+	if masterServerErr != nil {
+		return fmt.Errorf("fail to run master server: %s", masterServerErr)
+	}
+
+	// 3. start the agent server
+	agentServerErr := runAgentServer(ats.tlsCfg, ats.serverAgentAddr, proxyServer)
+	if agentServerErr != nil {
+		return fmt.Errorf("fail to run agent server: %s", agentServerErr)
+	}
+
+	return nil
+}
+
+// runProxier starts a proxy server that redirects requests received from
+// apiserver to corresponding yurttunel-agent
+func runProxier(handler http.Handler,
+	egressSelectorEnabled bool,
+	udsSockFile string,
+	tlsConfig *tls.Config) error {
+	klog.Info("start handling request from interceptor")
+	if egressSelectorEnabled {
+		// TODO will support egress selector for apiserver version > 1.18
+		return errors.New("DOESN'T SUPPROT EGRESS SELECTOR YET")
+	}
+	// request will be sent from request interceptor on the same host,
+	// so we use UDS protocol to avoide sending request through kernel
+	// network stack.
+	go func() {
+		server := &http.Server{
+			Handler: handler,
+		}
+		unixListener, err := net.Listen("unix", udsSockFile)
+		if err != nil {
+			klog.Errorf("proxier fail to serving request through uds: %s", err)
+		}
+		defer unixListener.Close()
+		if err := server.Serve(unixListener); err != nil {
+			klog.Errorf("proxier fail to serving request through uds: %s", err)
+		}
+	}()
+
+	return nil
+}
+
+// runMasterServer runs an https server to handle requests from apiserver
+func runMasterServer(handler http.Handler,
+	egressSelectorEnabled bool,
+	masterServerAddr,
+	masterServerInsecureAddr string,
+	tlsCfg *tls.Config) error {
+	if egressSelectorEnabled {
+		return errors.New("DOESN'T SUPPORT EGRESS SELECTOR YET")
+	}
+	go func() {
+		klog.Infof("start handling https request from master at %s", masterServerAddr)
+		server := http.Server{
+			Addr:         masterServerAddr,
+			Handler:      handler,
+			TLSConfig:    tlsCfg,
+			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+		}
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			klog.Errorf("failed to serve https request from master: %v", err)
+		}
+	}()
+
+	go func() {
+		klog.Infof("start handling http request from master at %s", masterServerInsecureAddr)
+		server := http.Server{
+			Addr:         masterServerInsecureAddr,
+			Handler:      handler,
+			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+		}
+		if err := server.ListenAndServe(); err != nil {
+			klog.Errorf("failed to serve http request from master: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// runAgentServer runs a grpc server that handles connections from the yurttunel-agent
+// NOTE agent server is responsible for managing grpc connection yurttunel-server
+// and yurttunnel-agent, and the proxy server is responsible for redirecting requests
+// to corresponding yurttunel-agent
+func runAgentServer(tlsCfg *tls.Config,
+	agentServerAddr string,
+	proxyServer *anpserver.ProxyServer) error {
+	serverOption := grpc.Creds(credentials.NewTLS(tlsCfg))
+	grpcServer := grpc.NewServer(serverOption)
+	anpagent.RegisterAgentServiceServer(grpcServer, proxyServer)
+	listener, err := net.Listen("tcp", agentServerAddr)
+	klog.Info("start handling connection from agents")
+	if err != nil {
+		return fmt.Errorf("fail to listen to agent on %s: %s", agentServerAddr, err)
+	}
+	go grpcServer.Serve(listener)
+	return nil
+}

--- a/pkg/yurttunnel/server/cmd.go
+++ b/pkg/yurttunnel/server/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"time"
@@ -158,8 +157,6 @@ func (o *YurttunnelServerOptions) complete() error {
 
 // run starts the yurttunel-server
 func (o *YurttunnelServerOptions) run(stopCh <-chan struct{}) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// 1. start the IP table manager
 	if o.enableIptables {
 		iptablesMgr := iptables.NewIptablesManager(o.clientset,
@@ -209,13 +206,14 @@ func (o *YurttunnelServerOptions) run(stopCh <-chan struct{}) error {
 	}
 
 	// 5. start the server
-	if err := RunServer(ctx,
+	ts := NewTunnelServer(
 		o.egressSelectorEnabled,
 		o.interceptorServerUDSFile,
 		o.serverMasterAddr,
 		o.serverMasterInsecureAddr,
 		o.serverAgentAddr,
-		tlsCfg); err != nil {
+		tlsCfg)
+	if err := ts.Run(); err != nil {
 		return err
 	}
 

--- a/pkg/yurttunnel/server/server.go
+++ b/pkg/yurttunnel/server/server.go
@@ -17,148 +17,30 @@ limitations under the License.
 package server
 
 import (
-	"context"
 	"crypto/tls"
-	"errors"
-	"fmt"
-	"net"
-	"net/http"
-
-	"github.com/google/uuid"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"k8s.io/klog"
-
-	anpserver "sigs.k8s.io/apiserver-network-proxy/pkg/server"
-	anpagent "sigs.k8s.io/apiserver-network-proxy/proto/agent"
 )
 
-// RunServer runs the yurttunnel-server
-func RunServer(ctx context.Context,
+// TunnelServermanages tunnels between itself and agents, receives requests
+// from apiserver, and forwards requests to corresponding agents
+type TunnelServer interface {
+	Run() error
+}
+
+// NewTunnelServer returns a new TunnelServer
+func NewTunnelServer(
 	egressSelectorEnabled bool,
 	interceptorServerUDSFile,
 	serverMasterAddr,
 	serverMasterInsecureAddr,
 	serverAgentAddr string,
-	tlsCfg *tls.Config) error {
-	proxyServer := anpserver.NewProxyServer(uuid.New().String(), 1,
-		&anpserver.AgentTokenAuthenticationOptions{})
-
-	// 1. start the proxier
-	proxierErr := runProxier(&anpserver.Tunnel{Server: proxyServer},
-		egressSelectorEnabled,
-		interceptorServerUDSFile,
-		tlsCfg)
-	if proxierErr != nil {
-		return fmt.Errorf("fail to run the proxier: %s", proxierErr)
+	tlsCfg *tls.Config) TunnelServer {
+	ats := anpTunnelServer{
+		egressSelectorEnabled:    egressSelectorEnabled,
+		interceptorServerUDSFile: interceptorServerUDSFile,
+		serverMasterAddr:         serverMasterAddr,
+		serverMasterInsecureAddr: serverMasterInsecureAddr,
+		serverAgentAddr:          serverAgentAddr,
+		tlsCfg:                   tlsCfg,
 	}
-
-	// 2. start the master server
-	masterServerErr := runMasterServer(
-		&RequestInterceptor{
-			UDSSockFile: interceptorServerUDSFile,
-			TLSConfig:   tlsCfg,
-		},
-		egressSelectorEnabled,
-		serverMasterAddr,
-		serverMasterInsecureAddr,
-		tlsCfg)
-	if masterServerErr != nil {
-		return fmt.Errorf("fail to run master server: %s", masterServerErr)
-	}
-
-	// 3. start the agent server
-	agentServerErr := runAgentServer(tlsCfg, serverAgentAddr, proxyServer)
-	if agentServerErr != nil {
-		return fmt.Errorf("fail to run agent server: %s", agentServerErr)
-	}
-
-	return nil
-}
-
-// runProxier starts a proxy server that redirects requests received from
-// apiserver to corresponding yurttunel-agent
-func runProxier(handler http.Handler,
-	egressSelectorEnabled bool,
-	udsSockFile string,
-	tlsConfig *tls.Config) error {
-	klog.Info("start handling request from interceptor")
-	if egressSelectorEnabled {
-		// TODO will support egress selector for apiserver version > 1.18
-		return errors.New("DOESN'T SUPPROT EGRESS SELECTOR YET")
-	}
-	// request will be sent from request interceptor on the same host,
-	// so we use UDS protocol to avoide sending request through kernel
-	// network stack.
-	go func() {
-		server := &http.Server{
-			Handler: handler,
-		}
-		unixListener, err := net.Listen("unix", udsSockFile)
-		if err != nil {
-			klog.Errorf("proxier fail to serving request through uds: %s", err)
-		}
-		defer unixListener.Close()
-		if err := server.Serve(unixListener); err != nil {
-			klog.Errorf("proxier fail to serving request through uds: %s", err)
-		}
-	}()
-
-	return nil
-}
-
-// runMasterServer runs an https server to handle requests from apiserver
-func runMasterServer(handler http.Handler,
-	egressSelectorEnabled bool,
-	masterServerAddr,
-	masterServerInsecureAddr string,
-	tlsCfg *tls.Config) error {
-	if egressSelectorEnabled {
-		return errors.New("DOESN'T SUPPORT EGRESS SELECTOR YET")
-	}
-	go func() {
-		klog.Infof("start handling https request from master at %s", masterServerAddr)
-		server := http.Server{
-			Addr:         masterServerAddr,
-			Handler:      handler,
-			TLSConfig:    tlsCfg,
-			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
-		}
-		if err := server.ListenAndServeTLS("", ""); err != nil {
-			klog.Errorf("failed to serve https request from master: %v", err)
-		}
-	}()
-
-	go func() {
-		klog.Infof("start handling http request from master at %s", masterServerInsecureAddr)
-		server := http.Server{
-			Addr:         masterServerInsecureAddr,
-			Handler:      handler,
-			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
-		}
-		if err := server.ListenAndServe(); err != nil {
-			klog.Errorf("failed to serve http request from master: %v", err)
-		}
-	}()
-
-	return nil
-}
-
-// runAgentServer runs a grpc server that handles connections from the yurttunel-agent
-// NOTE agent server is responsible for managing grpc connection yurttunel-server
-// and yurttunnel-agent, and the proxy server is responsible for redirecting requests
-// to corresponding yurttunel-agent
-func runAgentServer(tlsCfg *tls.Config,
-	agentServerAddr string,
-	proxyServer *anpserver.ProxyServer) error {
-	serverOption := grpc.Creds(credentials.NewTLS(tlsCfg))
-	grpcServer := grpc.NewServer(serverOption)
-	anpagent.RegisterAgentServiceServer(grpcServer, proxyServer)
-	listener, err := net.Listen("tcp", agentServerAddr)
-	klog.Info("start handling connection from agents")
-	if err != nil {
-		return fmt.Errorf("fail to listen to agent on %s: %s", agentServerAddr, err)
-	}
-	go grpcServer.Serve(listener)
-	return nil
+	return &ats
 }


### PR DESCRIPTION
1. implement the handlerwrapper, which takes in one http.handler and wraps it within another
2. decouple the anp tunnel server/agent using TunnelServer and TunnelAgent interface