### PR TITLE
Feature: Deploy the yurt-tunnel using yurtctl convert option

### DIFF
--- a/cmd/yurt-tunnel-agent/agent.go
+++ b/cmd/yurt-tunnel-agent/agent.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/agent"
-	"github.com/alibaba/openyurt/pkg/yurttunnel/projectinfo"
 )
 
 func main() {

--- a/cmd/yurt-tunnel-server/server.go
+++ b/cmd/yurt-tunnel-server/server.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 
-	"github.com/alibaba/openyurt/pkg/yurttunnel/projectinfo"
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/server"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"

--- a/config/yurtctl-servant/setup_edgenode
+++ b/config/yurtctl-servant/setup_edgenode
@@ -221,7 +221,7 @@ revert_kubelet() {
         mv ${KUBELET_SVC}.bk $KUBELET_SVC
     else
         # if the backup file doesn't not exist, revise the kubelet.service drop-in
-        log "didn't find the ${KUBELET_SVC}.bk, will revise the $KUBELE_SVC directly"
+        log "didn't find the ${KUBELET_SVC}.bk, will revise the $KUBELET_SVC directly"
         sed -i "s|--kubeconfig=.*kubelet.conf|--kubeconfig=$KUBELET_CONF|g;" $KUBELET_SVC
         log "revised the kubelet.service drop-in file back to the default"
     fi

--- a/pkg/projectinfo/projectinfo.go
+++ b/pkg/projectinfo/projectinfo.go
@@ -26,29 +26,9 @@ var (
 	gitVersion    = "v0.0.0"
 	gitCommit     = "unknown"
 	buildDate     = "1970-01-01T00:00:00Z"
+	compiler      = runtime.Compiler
+	platform      = runtime.GOOS + "/" + runtime.GOARCH
 )
-
-type ProjectInfo struct {
-	ProjectPrefix string
-	LabelPrefix   string
-	GitVersion    string
-	GitCommit     string
-	BuildDate     string
-	Compiler      string
-	Platform      string
-}
-
-func Get() ProjectInfo {
-	return ProjectInfo{
-		ProjectPrefix: projectPrefix,
-		LabelPrefix:   labelPrefix,
-		GitVersion:    gitVersion,
-		GitCommit:     gitCommit,
-		BuildDate:     buildDate,
-		Compiler:      runtime.Compiler,
-		Platform:      runtime.GOOS + "/" + runtime.GOARCH,
-	}
-}
 
 func ShortAgentVersion() string {
 	commit := gitCommit
@@ -66,10 +46,20 @@ func ShortServerVersion() string {
 	return GetServerName() + "/" + gitVersion + "-" + commit
 }
 
+func GetProjectPrefix() string {
+	return projectPrefix
+}
+
 func GetServerName() string {
-	return Get().ProjectPrefix + "tunnel-server"
+	return projectPrefix + "tunnel-server"
 }
 
 func GetAgentName() string {
-	return Get().ProjectPrefix + "tunnel-agent"
+	return projectPrefix + "tunnel-agent"
+}
+
+// GetEdgeWorkerLabelKey returns the edge-worker label, which is used to
+// identify if a node is a edge node ("true") or a cloud node ("false")
+func GetEdgeWorkerLabelKey() string {
+	return labelPrefix + "/is-edge-worker"
 }

--- a/pkg/yurtctl/cmd/cmd.go
+++ b/pkg/yurtctl/cmd/cmd.go
@@ -43,7 +43,7 @@ func NewYurtctlCommand() *cobra.Command {
 	cmds.AddCommand(markautonomous.NewMarkAutonomousCmd())
 
 	klog.InitFlags(nil)
-	goflag.Parse()
+	// goflag.Parse()
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	return cmds

--- a/pkg/yurtctl/cmd/markautonomous/markautonomous.go
+++ b/pkg/yurtctl/cmd/markautonomous/markautonomous.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurtctl/constants"
 	"github.com/alibaba/openyurt/pkg/yurtctl/lock"
 	kubeutil "github.com/alibaba/openyurt/pkg/yurtctl/util/kubernetes"
@@ -106,7 +107,7 @@ func (mao *MarkAutonomousOptions) RunMarkAutonomous() (err error) {
 	)
 	if mao.MarkAllEdgeNodes {
 		// make all edge nodes autonomous
-		labelSelector := fmt.Sprintf("%s=true", constants.LabelEdgeWorker)
+		labelSelector := fmt.Sprintf("%s=true", projectinfo.GetEdgeWorkerLabelKey())
 		edgeNodeList, err = mao.CoreV1().Nodes().
 			List(metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
@@ -127,7 +128,7 @@ func (mao *MarkAutonomousOptions) RunMarkAutonomous() (err error) {
 			if err != nil {
 				return
 			}
-			if node.Labels[constants.LabelEdgeWorker] == "false" {
+			if node.Labels[projectinfo.GetEdgeWorkerLabelKey()] == "false" {
 				err = fmt.Errorf("can't make cloud node(%s) autonomous",
 					node.GetName())
 				return

--- a/pkg/yurtctl/constants/constants.go
+++ b/pkg/yurtctl/constants/constants.go
@@ -17,14 +17,15 @@ limitations under the License.
 package constants
 
 const (
-	// LabelEdgeWorker is used to identify if a node is a edge node ("true")
-	// or a cloud node ("false")
-	LabelEdgeWorker = "alibabacloud.com/is-edge-worker"
-
 	// AnnotationAutonomy is used to identify if a node is automous
 	AnnotationAutonomy = "node.beta.alibabacloud.com/autonomy"
 
-	YurtctlLockConfigMapName = `yurtctl-lock`
+	YurtctlLockConfigMapName = "yurtctl-lock"
+
+	YurttunnelServerComponentName = "yurt-tunnel-server"
+	YurttunnelServerSvcName       = "x-tunnel-server-svc"
+	YurttunnelAgentComponentName  = "yurt-tunnel-agent"
+	YurttunnelNamespace           = "kube-system"
 
 	// YurtControllerManagerDeployment defines the yurt controller manager
 	// deployment in yaml format
@@ -51,7 +52,7 @@ spec:
           - weight: 1
             preference:
               matchExpressions:
-              - key: alibabacloud.com/is-edge-worker
+              - key: {{.edgeNodeLabel}}
                 operator: In
                 values:
                 - "false"

--- a/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	YurttunnelAgentClusterRole = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: yurt-tunnel-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/stats
+  - nodes/metrics
+  - nodes/log
+  - nodes/spec
+  - nodes/proxy
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - patch
+`
+	YurttunnelAgentClusterRoleBinding = `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: yurt-tunnel-agent
+subjects:
+- kind: Group
+  name: system:nodes
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: yurt-tunnel-agent
+  apiGroup: rbac.authorization.k8s.io
+`
+	YurttunnelAgentDaemonSet = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: yurt-tunnel-agent
+  name: yurt-tunnel-agent
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: yurt-tunnel-agent
+  template:
+    metadata:
+      labels:
+        k8s-app: yurt-tunnel-agent
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
+        {{.edgeWorkerLabel}}: "true"
+      containers:
+      - command:
+        - yurt-tunnel-agent
+        args:
+        - --node-name=$(NODE_NAME)
+        image: {{.image}}
+        imagePullPolicy: Always
+        name: yurt-tunnel-agent
+        volumeMounts:
+        - name: k8s-dir
+          mountPath: /etc/kubernetes
+        - name: kubelet-pki
+          mountPath: /var/lib/kubelet/pki
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      hostNetwork: true
+      restartPolicy: Always
+      volumes:
+      - name: k8s-dir
+        hostPath:
+          path: /etc/kubernetes
+          type: Directory
+      - name: kubelet-pki
+        hostPath:
+          path: /var/lib/kubelet/pki
+          type: Directory
+`
+)

--- a/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	YurttunnelServerClusterRole = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: yurt-tunnel-server
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - "kubernetes.io/legacy-unknown"
+  verbs:
+  - approve
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+`
+	YurttunnelServerServiceAccount = `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yurt-tunnel-server
+  namespace: kube-system
+`
+	YurttunnelServerClusterRolebinding = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yurt-tunnel-server
+subjects:
+  - kind: ServiceAccount
+    name: yurt-tunnel-server
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: yurt-tunnel-server
+  apiGroup: rbac.authorization.k8s.io
+`
+	YurttunnelServerService = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-tunnel-server-svc
+  namespace: kube-system
+  labels:
+    name: yurt-tunnel-server
+spec:
+  type: NodePort 
+  ports:
+  - port: 10263
+    targetPort: 10263
+    name: https
+  - port: 10262
+    targetPort: 10262
+    name: tcp
+  selector:
+    k8s-app: yurt-tunnel-server
+`
+	YurttunnelServerConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yurt-tunnel-server-cfg
+  namespace: kube-system
+data:
+  dnat-ports-pair: ""
+`
+	YurttunnelServerDeployment = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yurt-tunnel-server
+  namespace: kube-system
+  labels:
+    k8s-app: yurt-tunnel-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: yurt-tunnel-server
+  template:
+    metadata:
+      labels:
+        k8s-app: yurt-tunnel-server
+    spec:
+      hostNetwork: true
+      serviceAccountName: yurt-tunnel-server
+      restartPolicy: Always
+      tolerations:
+      - key: "node-role.alibabacloud.com/addon"
+        operator: "Exists"
+        effect: "NoSchedule"
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
+        {{.edgeWorkerLabel}}: "false"
+      containers:
+      - name: yurt-tunnel-server
+        image: {{.image}} 
+        imagePullPolicy: Always
+        command:
+        - yurt-tunnel-server
+        args:
+        - --bind-address=$(NODE_IP)
+        - --server-count=1
+        env:
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+`
+)

--- a/pkg/yurtctl/util/kubernetes/util.go
+++ b/pkg/yurtctl/util/kubernetes/util.go
@@ -62,7 +62,8 @@ var (
 		"1.12", "1.12+",
 		"1.13", "1.13+",
 		"1.14", "1.14+",
-		"1.16", "1.16+"}
+		"1.16", "1.16+",
+		"1.18", "1.18+"}
 )
 
 // YamlToObject deserializes object in yaml format to a runtime.Object

--- a/pkg/yurttunnel/agent/cmd.go
+++ b/pkg/yurttunnel/agent/cmd.go
@@ -26,11 +26,11 @@ import (
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/klog"
 
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
 	kubeutil "github.com/alibaba/openyurt/pkg/yurttunnel/kubernetes"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/pki"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/pki/certmanager"
-	"github.com/alibaba/openyurt/pkg/yurttunnel/projectinfo"
 )
 
 const defaultKubeconfig = "/etc/kubernetes/kubelet.conf"

--- a/pkg/yurttunnel/constants/constants.go
+++ b/pkg/yurttunnel/constants/constants.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package constants
 
-import (
-	"github.com/alibaba/openyurt/pkg/yurttunnel/projectinfo"
-)
-
 const (
 	YurttunnelServerAgentPort          = 10262
 	YurttunnelServerMasterPort         = 10263
@@ -55,9 +51,4 @@ const (
 	YurttunnelANPGrpcKeepAliveTimeSec = 10
 	// wait 5 seconds for the probe ack before cutting the connection
 	YurttunnelANPGrpcKeepAliveTimeoutSec = 5
-)
-
-var (
-	YurtEdgeNodeLabel          = projectinfo.Get().LabelPrefix + "/is-edge-worker"
-	YurttunnelEnableAgentLabel = projectinfo.Get().LabelPrefix + "/edge-enable-reverseTunnel-client"
 )

--- a/pkg/yurttunnel/iptables/iptables.go
+++ b/pkg/yurttunnel/iptables/iptables.go
@@ -37,8 +37,8 @@ import (
 	"k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
 
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
-	"github.com/alibaba/openyurt/pkg/yurttunnel/projectinfo"
 )
 
 const (
@@ -57,7 +57,7 @@ const (
 )
 
 var (
-	yurttunnelServerDnatConfigMapName = fmt.Sprintf("%stunnel-server-cfg", projectinfo.Get().ProjectPrefix)
+	yurttunnelServerDnatConfigMapName = fmt.Sprintf("%stunnel-server-cfg", projectinfo.GetProjectPrefix())
 )
 
 type iptablesJumpChain struct {
@@ -270,8 +270,8 @@ func (im *iptablesManager) getIPOfNodesWithoutAgent() []string {
 }
 
 func withoutAgent(node *corev1.Node) bool {
-	enableAgent, ok := node.Labels[constants.YurttunnelEnableAgentLabel]
-	if !ok || enableAgent != "true" {
+	edgeNode, ok := node.Labels[projectinfo.GetEdgeWorkerLabelKey()]
+	if !ok || edgeNode != "true" {
 		return true
 	}
 	return false

--- a/pkg/yurttunnel/pki/certmanager/certmanager.go
+++ b/pkg/yurttunnel/pki/certmanager/certmanager.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/klog"
 
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
 )
 
@@ -155,7 +156,7 @@ func getNodePortDNSandIP(
 	clientset kubernetes.Interface,
 	dnsNames []string,
 	ips []net.IP) ([]string, []net.IP, error) {
-	labelSelector := fmt.Sprintf("%s=false", constants.YurtEdgeNodeLabel)
+	labelSelector := fmt.Sprintf("%s=false", projectinfo.GetEdgeWorkerLabelKey())
 	// yurttunnel-server will be deployed on one of the cloud nodes
 	nodeLst, err := clientset.CoreV1().Nodes().List(
 		metav1.ListOptions{LabelSelector: labelSelector})

--- a/pkg/yurttunnel/server/anpserver.go
+++ b/pkg/yurttunnel/server/anpserver.go
@@ -44,6 +44,7 @@ type anpTunnelServer struct {
 	serverMasterAddr         string
 	serverMasterInsecureAddr string
 	serverAgentAddr          string
+	serverCount              int
 	tlsCfg                   *tls.Config
 }
 
@@ -51,7 +52,8 @@ var _ TunnelServer = &anpTunnelServer{}
 
 // Run runs the yurttunnel-server
 func (ats *anpTunnelServer) Run() error {
-	proxyServer := anpserver.NewProxyServer(uuid.New().String(), 1,
+	proxyServer := anpserver.NewProxyServer(uuid.New().String(),
+		ats.serverCount,
 		&anpserver.AgentTokenAuthenticationOptions{})
 	// 1. start the proxier
 	proxierErr := runProxier(

--- a/pkg/yurttunnel/server/server.go
+++ b/pkg/yurttunnel/server/server.go
@@ -33,6 +33,7 @@ func NewTunnelServer(
 	serverMasterAddr,
 	serverMasterInsecureAddr,
 	serverAgentAddr string,
+	serverCount int,
 	tlsCfg *tls.Config) TunnelServer {
 	ats := anpTunnelServer{
 		egressSelectorEnabled:    egressSelectorEnabled,
@@ -40,6 +41,7 @@ func NewTunnelServer(
 		serverMasterAddr:         serverMasterAddr,
 		serverMasterInsecureAddr: serverMasterInsecureAddr,
 		serverAgentAddr:          serverAgentAddr,
+		serverCount:              serverCount,
 		tlsCfg:                   tlsCfg,
 	}
 	return &ats

--- a/test/e2e/yurthub/yurthub.go
+++ b/test/e2e/yurthub/yurthub.go
@@ -18,6 +18,7 @@ package yurthub
 
 import (
 	"encoding/json"
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurtctl/constants"
 	nd "github.com/alibaba/openyurt/test/e2e/common/node"
 	"github.com/alibaba/openyurt/test/e2e/common/ns"
@@ -81,7 +82,7 @@ func Register() {
 				spec := apiv1.PodSpec{}
 				container := apiv1.Container{}
 				spec.HostNetwork = true
-				spec.NodeSelector = map[string]string{constants.LabelEdgeWorker: "true"}
+				spec.NodeSelector = map[string]string{projectinfo.GetEdgeWorkerLabelKey(): "true"}
 				container.Name = "busybox"
 				container.Image = "busybox"
 				container.Command = []string{"sleep", "3600"}

--- a/test/e2e/yurttunnel/yurttunnel.go
+++ b/test/e2e/yurttunnel/yurttunnel.go
@@ -20,6 +20,7 @@ package yurttunnel
 import (
 	"bytes"
 	"fmt"
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurtctl/constants"
 	"github.com/alibaba/openyurt/test/e2e/common/ns"
 	p "github.com/alibaba/openyurt/test/e2e/common/pod"
@@ -164,7 +165,6 @@ func Register() {
 		_, err = ns.CreateNameSpace(c, YURTTUNNEL_E2E_NAMESPACE_NAME)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "fail to create namespace")
 
-
 		framework.KubeDescribe(YURTTUNNEL_E2E_TEST_DESC+": pod_operate_test_on_edge", func() {
 			ginkgo.It("yurttunnel_e2e_test_pod_run_on_edge", func() {
 				cs := c
@@ -176,7 +176,7 @@ func Register() {
 				spec := apiv1.PodSpec{}
 				container := apiv1.Container{}
 				spec.HostNetwork = true
-				spec.NodeSelector = map[string]string{constants.LabelEdgeWorker: "true"}
+				spec.NodeSelector = map[string]string{projectinfo.GetEdgeWorkerLabelKey(): "true"}
 				container.Name = "test-po-yurttunnel-on-edge"
 				container.Image = "busybox"
 				container.Command = []string{"sleep", "3600"}


### PR DESCRIPTION
1. allow users to deploy yurttunnel using `yurtctl convert`, for example: 

```bash
yurtctl convert --cloud-nodes minikube --provider minikube --deploy-yurttunnel
``` 
or

```bash
yurtctl convert --provider minikube -c minikube -t -v 4
```

2. if yurttunnel is deployed, `yurtctl revert` will remove it
3. share projectinfo across packages (i.e. yurtctl, yurttunnel, test)
