### PR TITLE
Bugfix: fix compile error when use customize settings

### DIFF
--- a/hack/lib/build.sh
+++ b/hack/lib/build.sh
@@ -32,33 +32,21 @@ readonly YURT_YAML_TARGETS=(
     yurt-tunnel-agent
 )
 
-PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
-LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
-GIT_VERSION="v0.1.1"
-GIT_COMMIT=$(git rev-parse HEAD)
-BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+#PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
+#LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
+#GIT_VERSION="v0.1.1"
+#GIT_COMMIT=$(git rev-parse HEAD)
+#BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # project_info generates the project information and the corresponding valuse 
 # for 'ldflags -X' option
 project_info() {
-    PROJECT_INFO_PKG=${YURT_MOD}/pkg/yurttunnel/projectinfo
+    PROJECT_INFO_PKG=${YURT_MOD}/pkg/projectinfo
     echo "-X ${PROJECT_INFO_PKG}.projectPrefix=${PROJECT_PREFIX}"
     echo "-X ${PROJECT_INFO_PKG}.labelPrefix=${LABEL_PREFIX}"
     echo "-X ${PROJECT_INFO_PKG}.gitVersion=${GIT_VERSION}"
     echo "-X ${PROJECT_INFO_PKG}.gitCommit=${GIT_COMMIT}"
     echo "-X ${PROJECT_INFO_PKG}.buildDate=${BUILD_DATE}"
-}
-
-# get_output_name generates the executable's name. If the $PROJECT_PREFIX
-# is set, it subsitutes the prefix of the executable's name with the env, 
-# otherwise the basename of the target is used
-get_output_name() {
-    local oup_name=$1
-    PROJECT_PREFIX=${PROJECT_PREFIX:-}
-    if [ ! -z $PROJECT_PREFIX ]; then
-        oup_name=${oup_name/yurt/$PROJECT_PREFIX}
-    fi
-    echo $oup_name
 }
 
 # get_binary_dir_with_arch generated the binary's directory with GOOS and GOARCH.
@@ -96,7 +84,7 @@ build_binaries() {
       echo "Building ${binary}"
       go build -o $(get_output_name $binary) \
           -ldflags "${goldflags:-}" \
-          -gcflags "${gcflags:-}" ${goflags} $YURT_ROOT/cmd/${binary}
+          -gcflags "${gcflags:-}" ${goflags} $YURT_ROOT/cmd/$(canonicalize_target $binary)
     done
 }
 

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -1,0 +1,45 @@
+# Copyright 2020 The OpenYurt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+
+set -x
+
+# get_output_name generates the executable's name. If the $PROJECT_PREFIX
+# is set, it subsitutes the prefix of the executable's name with the env,
+# otherwise the basename of the target is used
+get_output_name() {
+    local oup_name=$(canonicalize_target $1)
+    PROJECT_PREFIX=${PROJECT_PREFIX:-}
+    if [ -z $PROJECT_PREFIX ]; then
+        oup_name=${oup_name}
+    elif [ "$PROJECT_PREFIX" = "yurt" ]; then
+        oup_name=${oup_name}
+    else
+        oup_name=${oup_name/yurt-/$PROJECT_PREFIX}
+        oup_name=${oup_name/yurt/$PROJECT_PREFIX}
+    fi
+    echo $oup_name
+}
+
+# canonicalize_target delete the first four characters when
+# target begins with "cmd/"
+canonicalize_target() {
+    local target=$1
+    if [[ "$target" =~ ^cmd/.* ]]; then
+        target=${target:4}
+    fi
+
+    echo $target
+}

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -23,5 +23,14 @@ YURT_MOD="$(head -1 $YURT_ROOT/go.mod | awk '{print $2}')"
 YURT_OUTPUT_DIR=${YURT_ROOT}/_output
 YURT_BIN_DIR=${YURT_OUTPUT_DIR}/bin
 
+PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
+LABEL_PREFIX=${LABEL_PREFIX:-openyurt.io}
+GIT_VERSION="v0.2.0"
+GIT_COMMIT=$(git rev-parse HEAD)
+BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+REPO="openyurt"
+TAG=$GIT_VERSION
+
+source "${YURT_ROOT}/hack/lib/common.sh"
 source "${YURT_ROOT}/hack/lib/build.sh"
 source "${YURT_ROOT}/hack/lib/release-images.sh"

--- a/hack/make-rules/release-images.sh
+++ b/hack/make-rules/release-images.sh
@@ -14,6 +14,8 @@
 
 #!/usr/bin/env bash
 
+set -x
+
 YURT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${YURT_ROOT}/hack/lib/init.sh" 
 


### PR DESCRIPTION
1. enable compile when use WHAT string begins with cmd/, for example: make build WHAT=cmd/yurthub
2. fix customize project info(for example: PROJECT_PREFIX=edge) compile error for make build/release