### PR TITLE
Refactor: refactor hub log without yurt instead of using projectinfo

### DIFF
--- a/cmd/yurthub/app/config/config.go
+++ b/cmd/yurthub/app/config/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/openyurt/cmd/yurthub/app/options"
+	"github.com/alibaba/openyurt/pkg/projectinfo"
 
 	"k8s.io/klog"
 )
@@ -71,7 +72,7 @@ func parseRemoteServers(serverAddr string) ([]*url.URL, error) {
 	if len(us) < 1 {
 		return us, fmt.Errorf("no server address is set, can not connect remote server")
 	}
-	klog.Infof("yurthub would connect remote servers: %s", strings.Join(remoteServers, ","))
+	klog.Infof("%s would connect remote servers: %s", projectinfo.GetHubName(), strings.Join(remoteServers, ","))
 
 	return us, nil
 }

--- a/cmd/yurthub/app/options/options.go
+++ b/cmd/yurthub/app/options/options.go
@@ -62,12 +62,12 @@ func ValidateOptions(options *YurtHubOptions) error {
 
 // AddFlags returns flags for a specific yurthub by section name
 func (o *YurtHubOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.YurtHubHost, "yurt-hub-host", o.YurtHubHost, "the host that used to connect yurthub.")
-	fs.IntVar(&o.YurtHubPort, "yurt-hub-port", o.YurtHubPort, "the port that used to connect yurthub.")
+	fs.StringVar(&o.YurtHubHost, "bind-address", o.YurtHubHost, "the IP address on which to listen for the --serve-port port.")
+	fs.IntVar(&o.YurtHubPort, "serve-port", o.YurtHubPort, "the port on which to serve HTTP.")
 	fs.StringVar(&o.ServerAddr, "server-addr", o.ServerAddr, "the address of Kubernetes kube-apiserver,the format is: \"server1,server2,...\"")
 	fs.StringVar(&o.CertMgrMode, "cert-mgr-mode", o.CertMgrMode, "the cert manager mode, kubelet: use certificates that belongs to kubelet")
 	fs.IntVar(&o.GCFrequency, "gc-frequency", o.GCFrequency, "the frequency to gc cache in storage(unit: minute).")
-	fs.StringVar(&o.NodeName, "node-name", o.NodeName, "the name of node that runs yurthub")
+	fs.StringVar(&o.NodeName, "node-name", o.NodeName, "the name of node that runs hub agent")
 	fs.StringVar(&o.LBMode, "lb-mode", o.LBMode, "the mode of load balancer to connect remote servers(rr, priority)")
 	fs.IntVar(&o.HeartbeatFailedRetry, "heartbeat-failed-retry", o.HeartbeatFailedRetry, "number of heartbeat request retry after having failed.")
 	fs.IntVar(&o.HeartbeatHealthyThreshold, "heartbeat-healthy-threshold", o.HeartbeatHealthyThreshold, "minimum consecutive successes for the heartbeat to be considered healthy after having failed.")

--- a/pkg/projectinfo/projectinfo.go
+++ b/pkg/projectinfo/projectinfo.go
@@ -63,3 +63,8 @@ func GetAgentName() string {
 func GetEdgeWorkerLabelKey() string {
 	return labelPrefix + "/is-edge-worker"
 }
+
+// GetHubName returns name of yurthub agent
+func GetHubName() string {
+	return projectPrefix + "hub"
+}

--- a/pkg/yurthub/certificate/kubelet/cert_mgr.go
+++ b/pkg/yurthub/certificate/kubelet/cert_mgr.go
@@ -69,7 +69,7 @@ func NewKubeletCertManager(cfg *config.YurtHubConfiguration, period time.Duratio
 	var cert *tls.Certificate
 	var pairFile string
 	if cfg == nil || len(cfg.RemoteServers) == 0 {
-		return nil, fmt.Errorf("yurthub configuration is invalid")
+		return nil, fmt.Errorf("hub configuration is invalid")
 	}
 
 	if period == time.Duration(0) {


### PR DESCRIPTION
because of user can define name of hub by using makefile PROJECT_PREFIX setting, so hub log should not include “yurt” string. and it's need to keep consistent with  the name of hub.