### PR TITLE
Feature: add handler for updating join token for hub agent

### DIFF
--- a/pkg/yurthub/server/certificate.go
+++ b/pkg/yurthub/server/certificate.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/alibaba/openyurt/cmd/yurthub/app/config"
+)
+
+const (
+	tokenKey = "jointoken"
+)
+
+// updateToken update bootstrap token in the bootstrap-hub.conf file
+// in order to update node certificate when both node certificate and
+// old join token expires
+func (s *yurtHubServer) updateToken(w http.ResponseWriter, r *http.Request) {
+	tokens := make(map[string]string)
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&tokens)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = fmt.Fprintf(w, "could not decode tokens, %v", err)
+		return
+	}
+
+	joinToken := tokens[tokenKey]
+	if len(joinToken) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "no join token is set")
+		return
+	}
+
+	err = s.certificateMgr.Update(&config.YurtHubConfiguration{JoinToken: joinToken})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "could not update bootstrap token, %v", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, "update bootstrap token successfully")
+	return
+
+}

--- a/pkg/yurthub/server/server.go
+++ b/pkg/yurthub/server/server.go
@@ -65,6 +65,9 @@ func (s *yurtHubServer) Run() {
 }
 
 func (s *yurtHubServer) registerHandler() {
+	// register handlers for update join token
+	s.mux.HandleFunc("/v1/token", s.updateToken).Methods("POST", "PUT")
+
 	// register handler for health check
 	s.mux.HandleFunc("/v1/healthz", s.healthz).Methods("GET")
 


### PR DESCRIPTION
- feature background:
when the following conditions are met at the same time, the node certificate cannot be updated normally even if the cloud-edge network is restored.
  - the cloud-edge network is disconnected
  - node certificate expires
  - bootstrap token expires

- solution:
an API is provided that allows users to update the bootstrap token to rotate certificates.

- the command for update join token:
  curl -XPUT -d '{"jointoken": "newxxx.jointokenxxx"}' "http://127.0.0.1:10261/v1/token"