### PR TITLE
refactor: when cache data of hub agent is removed not on purpose, return 404 instead of empty objects for kubelet request

### DIFF
--- a/pkg/yurthub/proxy/util/util.go
+++ b/pkg/yurthub/proxy/util/util.go
@@ -164,7 +164,7 @@ func WithMaxInFlightLimit(handler http.Handler, limit int) http.Handler {
 		case reqChan <- true:
 			handler.ServeHTTP(w, req)
 			<-reqChan
-			klog.Infof("%s request completed, left %d requests in flight", util.ReqString(req), len(reqChan))
+			klog.V(5).Infof("%s request completed, left %d requests in flight", util.ReqString(req), len(reqChan))
 		default:
 			// Return a 429 status indicating "Too Many Requests"
 			klog.Errorf("Too many requests, please try again later, %s", util.ReqString(req))

--- a/pkg/yurthub/storage/disk/storage.go
+++ b/pkg/yurthub/storage/disk/storage.go
@@ -171,7 +171,7 @@ func (ds *diskStorage) get(path string) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []byte{}, nil
+			return []byte{}, storage.ErrStorageNotFound
 		}
 		return nil, fmt.Errorf("failed to get bytes for %s, %v", key, err)
 	} else if info.Mode().IsRegular() {
@@ -231,7 +231,7 @@ func (ds *diskStorage) List(key string) ([][]byte, error) {
 	info, err := os.Stat(absKey)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return bb, nil
+			return bb, storage.ErrStorageNotFound
 		}
 		klog.Errorf("filed to list bytes for (%s), %v", key, err)
 		return nil, err

--- a/pkg/yurthub/storage/disk/storage_test.go
+++ b/pkg/yurthub/storage/disk/storage_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/alibaba/openyurt/pkg/yurthub/storage"
 )
 
 var (
@@ -238,8 +240,8 @@ func TestGetFileNotExist(t *testing.T) {
 	}
 
 	b, err := s.Get(tempKey)
-	if err != nil {
-		t.Errorf("Got error %v, get key %q", err, tempKey)
+	if err != storage.ErrStorageNotFound {
+		t.Errorf("Got error %v, expect error %v", err, storage.ErrStorageNotFound)
 	} else if len(b) != 0 {
 		t.Errorf("Wanted empty string got %s", string(b))
 	}
@@ -410,8 +412,8 @@ func TestListEmptyDir(t *testing.T) {
 	}
 
 	contents, err := s.List(tempDir)
-	if err != nil {
-		t.Errorf("Got error %v, unable list for %s", err, tempDir)
+	if err != storage.ErrStorageNotFound {
+		t.Errorf("Got error %v, expect error %v", err, storage.ErrStorageNotFound)
 	}
 
 	if len(contents) != 0 {

--- a/pkg/yurthub/storage/store.go
+++ b/pkg/yurthub/storage/store.go
@@ -23,6 +23,9 @@ import (
 // ErrStorageAccessConflict is an error for accessing key conflict
 var ErrStorageAccessConflict = errors.New("specified key is under accessing")
 
+// ErrStorageNotFound is an error for not found accessing key
+var ErrStorageNotFound = errors.New("specified key is not found")
+
 // Store is an interface for caching data into backend storage
 type Store interface {
 	Create(key string, contents []byte) error


### PR DESCRIPTION
- background:
   1. at present, when cache data of yurthub(under /etc/kubernetes/cache directory) is removed, local proxy will return empty object slice for kubelet request.
   2. when network between edge and cloud is disconnected, yurthub will use empty cache to response kubelet request. if response of list pods request is empty objects slice(len(ListPods.Items[])=0)，all pods that are running on the current node will be killed. so it will effect the edge business.

- solution:
   if specified data is not found in cache data(for example: list pods)，yurthub not return empty objects slice for request, yurthub will return 404 status code for request, so kubelet only re-request data but not kill pods.