### PR TITLE
refactor: add initializer for adding sharedinformerfactory into middleware and register middleware explicitly by adding register func.

### DIFF
--- a/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
+++ b/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
@@ -18,9 +18,20 @@ package handlerwrapper
 
 import (
 	"net/http"
+
+	"k8s.io/klog"
 )
 
 // Middleware takes in one Handler and wrap it within another
-type Middleware func(http.Handler) http.Handler
+type Middleware interface {
+	WrapHandler(http.Handler) http.Handler
+	Name() string
+}
 
 var Middlewares []Middleware
+
+// Register an middleware
+func Register(m Middleware) {
+	klog.Infof("register middleware: %s", m.Name())
+	Middlewares = append(Middlewares, m)
+}

--- a/pkg/yurttunnel/handlerwrapper/initializer/initalizer.go
+++ b/pkg/yurttunnel/handlerwrapper/initializer/initalizer.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
+	"k8s.io/client-go/informers"
+)
+
+// WantsSharedInformerFactory is an interface for setting SharedInformerFactory
+type WantsSharedInformerFactory interface {
+	SetSharedInformerFactory(factory informers.SharedInformerFactory) error
+}
+
+// MiddlewareInitializer is an interface for initializing middleware
+type MiddlewareInitializer interface {
+	Initialize(m handlerwrapper.Middleware) error
+}
+
+// middlewareInitializer is responsible for initializing middleware
+type middlewareInitializer struct {
+	factory informers.SharedInformerFactory
+}
+
+// NewMiddlewareInitializer creates an MiddlewareInitializer object
+func NewMiddlewareInitializer(factory informers.SharedInformerFactory) MiddlewareInitializer {
+	return &middlewareInitializer{
+		factory: factory,
+	}
+}
+
+// Initialize used for executing middleware initialization
+func (mi *middlewareInitializer) Initialize(m handlerwrapper.Middleware) error {
+	if wants, ok := m.(WantsSharedInformerFactory); ok {
+		if err := wants.SetSharedInformerFactory(mi.factory); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
+++ b/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package printreqinfo
+package tracerequest
 
 import (
 	"net/http"
@@ -25,19 +25,26 @@ import (
 	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
 )
 
-func init() {
-	hw.Middlewares = append(hw.Middlewares, PrintReqInfoMiddleware)
+// TraceReqMiddleware prints request information when start/stop
+// handling the request
+type traceReqMiddleware struct{}
+
+// NewTraceReqMiddleware returns an middleware object
+func NewTraceReqMiddleware() hw.Middleware {
+	return &traceReqMiddleware{}
 }
 
-// PrintReqInfoMiddleware prints request information when start/stop
-// handling the request
-var PrintReqInfoMiddleware = func(handler http.Handler) http.Handler {
+func (trm *traceReqMiddleware) Name() string {
+	return "TraceReqMiddleware"
+}
+
+func (trm *traceReqMiddleware) WrapHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		klog.V(4).Infof("start handling request %s %s, from %s to %s",
+		klog.V(2).Infof("start handling request %s %s, from %s to %s",
 			req.Method, req.URL.String(), req.Host, req.RemoteAddr)
 		start := time.Now()
 		handler.ServeHTTP(w, req)
-		klog.V(4).Infof("stop handling request %s %s, request handling lasts %v",
+		klog.V(2).Infof("stop handling request %s %s, request handling lasts %v",
 			req.Method, req.URL.String(), time.Now().Sub(start))
 	})
 }

--- a/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
+++ b/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
@@ -20,31 +20,43 @@ import (
 	"net/http"
 
 	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
+	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
+	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/tracerequest"
 
-	// followings are the middleware packages
+	"k8s.io/klog"
+)
+
+func init() {
+	// register all of middleware here
 	//
-	// NOTE the package importing order decide the order in which
+	// NOTE the register order decide the order in which
 	// the middleware will be called
 	//
 	// e.g. there are two middleware mw1 and mw2
-	// if the packages are imported in the following order,
+	// if the middlewares are registered in the following order,
 	//
-	// _ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/mw2"
-	// _ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/mw1"
+	// hw.Register(mw2)
+	// hw.Register(mw1)
 	//
 	// then the middleware m2 will be called before the mw1
+	hw.Register(tracerequest.NewTraceReqMiddleware())
+}
 
-	_ "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/printreqinfo"
-)
-
-// WrapWrapHandler wraps the coreHandler with handlerwrapper.Middlewares
-func WrapHandler(coreHandler http.Handler) http.Handler {
+// WrapWrapHandler wraps the coreHandler with all of registered middleware
+// and middleware will be initialized before wrap.
+func WrapHandler(coreHandler http.Handler, mi initializer.MiddlewareInitializer) (http.Handler, error) {
 	handler := coreHandler
+	klog.V(4).Infof("%d middlewares will be added into wrap handler", len(hw.Middlewares))
 	if len(hw.Middlewares) == 0 {
-		return handler
+		return handler, nil
 	}
 	for i := len(hw.Middlewares) - 1; i >= 0; i-- {
-		handler = hw.Middlewares[i](handler)
+		if err := mi.Initialize(hw.Middlewares[i]); err != nil {
+			return handler, err
+		}
+
+		handler = hw.Middlewares[i].WrapHandler(handler)
+		klog.V(2).Infof("add %s into wrap handler", hw.Middlewares[i].Name())
 	}
-	return handler
+	return handler, nil
 }

--- a/pkg/yurttunnel/server/server.go
+++ b/pkg/yurttunnel/server/server.go
@@ -18,6 +18,8 @@ package server
 
 import (
 	"crypto/tls"
+
+	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
 )
 
 // TunnelServermanages tunnels between itself and agents, receives requests
@@ -34,7 +36,8 @@ func NewTunnelServer(
 	serverMasterInsecureAddr,
 	serverAgentAddr string,
 	serverCount int,
-	tlsCfg *tls.Config) TunnelServer {
+	tlsCfg *tls.Config,
+	initializer initializer.MiddlewareInitializer) TunnelServer {
 	ats := anpTunnelServer{
 		egressSelectorEnabled:    egressSelectorEnabled,
 		interceptorServerUDSFile: interceptorServerUDSFile,
@@ -43,6 +46,7 @@ func NewTunnelServer(
 		serverAgentAddr:          serverAgentAddr,
 		serverCount:              serverCount,
 		tlsCfg:                   tlsCfg,
+		initializer:              initializer,
 	}
 	return &ats
 }


### PR DESCRIPTION
- background:
1. the package importing order decide the order in which the middleware will be called, but the go fmt will modify the import order automatically. so the import order can not take effect.
2. wrap handler is useful for user to extend ability of tunnel server handler, but if the extended handler need some setting from outside, there is no way at present.

- solution
1. add `Register()` func and register wrap handler explicitly in init() func.
2. add initializer for adding setting(like sharedinformerfactory) into wrap handler(middleware)