### PR TITLE
Create CM for configuration of request redirect to tunnel server

### DIFF
--- a/pkg/yurtctl/cmd/convert/convert.go
+++ b/pkg/yurtctl/cmd/convert/convert.go
@@ -324,8 +324,14 @@ func deployYurttunnelServer(
 		constants.YurttunnelServerService); err != nil {
 		return err
 	}
+	// 5. create the Configmap
+	if err := kubeutil.CreateConfigMapFromYaml(client,
+		"kube-system",
+		constants.YurttunnelServerConfigMap); err != nil {
+		return err
+	}
 
-	// 5. create the Deployment
+	// 6. create the Deployment
 	if err := kubeutil.CreateDeployFromYaml(client,
 		"kube-system",
 		constants.YurttunnelServerDeployment,

--- a/pkg/yurtctl/cmd/revert/revert.go
+++ b/pkg/yurtctl/cmd/revert/revert.go
@@ -237,6 +237,14 @@ func removeYurtTunnelServer(client *kubernetes.Clientset) error {
 		return fmt.Errorf("fail to delete the clusterrole/%s: %s",
 			constants.YurttunnelServerComponentName, err)
 	}
+
+	// 6. remove the ConfigMap
+	if err := client.CoreV1().ConfigMaps(constants.YurttunnelNamespace).
+		Delete(constants.YurttunnelServerCmName,
+			&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("fail to delete the configmap/%s: %s",
+			constants.YurttunnelServerCmName, err)
+	}
 	klog.V(4).Infof("clusterrole/%s is deleted", constants.YurttunnelServerComponentName)
 	return nil
 }

--- a/pkg/yurtctl/constants/constants.go
+++ b/pkg/yurtctl/constants/constants.go
@@ -24,6 +24,7 @@ const (
 
 	YurttunnelServerComponentName = "yurt-tunnel-server"
 	YurttunnelServerSvcName       = "x-tunnel-server-svc"
+	YurttunnelServerCmName        = "yurt-tunnel-server-cfg"
 	YurttunnelAgentComponentName  = "yurt-tunnel-agent"
 	YurttunnelNamespace           = "kube-system"
 

--- a/pkg/yurtctl/util/kubernetes/util.go
+++ b/pkg/yurtctl/util/kubernetes/util.go
@@ -123,6 +123,24 @@ func CreateClusterRoleBindingFromYaml(cliSet *kubernetes.Clientset, crbTmpl stri
 	return nil
 }
 
+// CreateConfigMapFromYaml creates the ConfigMap from the yaml template.
+func CreateConfigMapFromYaml(cliSet *kubernetes.Clientset, ns, cmTmpl string) error {
+	obj, err := YamlToObject([]byte(cmTmpl))
+	if err != nil {
+		return err
+	}
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		return fmt.Errorf("fail to assert configmap: %v", err)
+	}
+	_, err = cliSet.CoreV1().ConfigMaps(ns).Create(cm)
+	if err != nil {
+		return fmt.Errorf("fail to create the configmap/%s: %v", cm.Name, err)
+	}
+	klog.V(4).Infof("configmap/%s is created", cm.Name)
+	return nil
+}
+
 // CreateDeployFromYaml creates the Deployment from the yaml template.
 func CreateDeployFromYaml(cliSet *kubernetes.Clientset, ns, dplyTmpl string, context interface{}) error {
 	ycmdp, err := tmplutil.SubsituteTemplate(dplyTmpl, context)


### PR DESCRIPTION
Found no ` such Comfigmap`: `kube-system/yurttunnel-server-cfg` created when use `yurtctl` when I try this:
https://github.com/alibaba/openyurt/issues/138#issuecomment-723555668