### PR TITLE
refactor: adapt k8s.io/klog/v2 for yurt tunnel

### DIFF
--- a/cmd/yurt-tunnel-agent/agent.go
+++ b/cmd/yurt-tunnel-agent/agent.go
@@ -20,13 +20,16 @@ import (
 	"flag"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/agent"
 )
 
 func main() {
+	klog.InitFlags(nil)
+	defer klog.Flush()
+
 	cmd := agent.NewYurttunnelAgentCommand(wait.NeverStop)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {

--- a/cmd/yurt-tunnel-server/server.go
+++ b/cmd/yurt-tunnel-server/server.go
@@ -22,10 +22,13 @@ import (
 	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/server"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {
+	klog.InitFlags(nil)
+	defer klog.Flush()
+
 	cmd := server.NewYurttunnelServerCommand(wait.NeverStop)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	k8s.io/client-go v0.17.3
 	k8s.io/component-base v0.16.9
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.0.0
 	k8s.io/kubernetes v1.18.3
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/apiserver-network-proxy v0.0.10

--- a/pkg/yurttunnel/agent/anpagent.go
+++ b/pkg/yurttunnel/agent/anpagent.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	anpagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 )
 

--- a/pkg/yurttunnel/agent/cmd.go
+++ b/pkg/yurttunnel/agent/cmd.go
@@ -18,14 +18,13 @@ package agent
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/certificate"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 
 	"github.com/alibaba/openyurt/pkg/projectinfo"
@@ -78,9 +77,6 @@ func NewYurttunnelAgentCommand(stopCh <-chan struct{}) *cobra.Command {
 	flags.StringVar(&o.agentIdentifiers, "agent-identifiers", o.agentIdentifiers,
 		"The identifiers of the agent, which will be used by the server when choosing agent.")
 
-	// add klog flags as the global flagsets
-	klog.InitFlags(nil)
-	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 

--- a/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
+++ b/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
@@ -19,7 +19,7 @@ package handlerwrapper
 import (
 	"net/http"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Middleware takes in one Handler and wrap it within another
@@ -32,6 +32,6 @@ var Middlewares []Middleware
 
 // Register an middleware
 func Register(m Middleware) {
-	klog.Infof("register middleware: %s", m.Name())
+	klog.V(4).Infof("register middleware: %s", m.Name())
 	Middlewares = append(Middlewares, m)
 }

--- a/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
+++ b/pkg/yurttunnel/handlerwrapper/tracerequest/tracereq.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
 )

--- a/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
+++ b/pkg/yurttunnel/handlerwrapper/wraphandler/wraphandler.go
@@ -19,11 +19,11 @@ package wraphandler
 import (
 	"net/http"
 
+	"k8s.io/klog/v2"
+
 	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/tracerequest"
-
-	"k8s.io/klog"
 )
 
 func init() {

--- a/pkg/yurttunnel/iptables/iptables.go
+++ b/pkg/yurttunnel/iptables/iptables.go
@@ -31,7 +31,7 @@ import (
 	coreinformer "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	utildbus "k8s.io/kubernetes/pkg/util/dbus"
 	"k8s.io/kubernetes/pkg/util/iptables"
 	"k8s.io/utils/exec"

--- a/pkg/yurttunnel/kubernetes/kubernetes.go
+++ b/pkg/yurttunnel/kubernetes/kubernetes.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
 )

--- a/pkg/yurttunnel/pki/certmanager/certmanager.go
+++ b/pkg/yurttunnel/pki/certmanager/certmanager.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clicert "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/util/certificate"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // NewYurttunnelServerCertManager creates a certificate manager for

--- a/pkg/yurttunnel/pki/certmanager/csrapprover.go
+++ b/pkg/yurttunnel/pki/certmanager/csrapprover.go
@@ -31,7 +31,7 @@ import (
 	typev1beta1 "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"

--- a/pkg/yurttunnel/server/anpserver.go
+++ b/pkg/yurttunnel/server/anpserver.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	anpserver "sigs.k8s.io/apiserver-network-proxy/pkg/server"
 	anpagent "sigs.k8s.io/apiserver-network-proxy/proto/agent"
 )

--- a/pkg/yurttunnel/server/cmd.go
+++ b/pkg/yurttunnel/server/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -33,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
 )
 
@@ -91,9 +90,6 @@ func NewYurttunnelServerCommand(stopCh <-chan struct{}) *cobra.Command {
 	flags.StringVar(&o.proxyStrategy, "proxy-strategy", o.proxyStrategy,
 		"The strategy of proxying requests from tunnel server to agent.")
 
-	// add klog flags as the global flagsets
-	klog.InitFlags(nil)
-	flags.AddGoFlagSet(flag.CommandLine)
 	return cmd
 }
 

--- a/pkg/yurttunnel/server/interceptor.go
+++ b/pkg/yurttunnel/server/interceptor.go
@@ -28,7 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
 )

--- a/pkg/yurttunnel/server/serveraddr/addr.go
+++ b/pkg/yurttunnel/server/serveraddr/addr.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // GetServerAddr gets the service address that exposes the tunnel server for


### PR DESCRIPTION
because underlying imported lib(anp) in yurt tunnel used klog/v2 as logger, so adapt klog/v2 in yurt tunnel for optimizing log output