### PR TITLE
refactor: create handler wrappers before new tunnel server

### DIFF
--- a/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
+++ b/pkg/yurttunnel/handlerwrapper/handlerwrapper.go
@@ -18,8 +18,6 @@ package handlerwrapper
 
 import (
 	"net/http"
-
-	"k8s.io/klog/v2"
 )
 
 // Middleware takes in one Handler and wrap it within another
@@ -28,10 +26,4 @@ type Middleware interface {
 	Name() string
 }
 
-var Middlewares []Middleware
-
-// Register an middleware
-func Register(m Middleware) {
-	klog.V(4).Infof("register middleware: %s", m.Name())
-	Middlewares = append(Middlewares, m)
-}
+type HandlerWrappers []Middleware

--- a/pkg/yurttunnel/server/anpserver.go
+++ b/pkg/yurttunnel/server/anpserver.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
-	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
+	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
 	wh "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/wraphandler"
 
 	"github.com/google/uuid"
@@ -47,7 +47,7 @@ type anpTunnelServer struct {
 	serverAgentAddr          string
 	serverCount              int
 	tlsCfg                   *tls.Config
-	initializer              initializer.MiddlewareInitializer
+	wrappers                 hw.HandlerWrappers
 	proxyStrategy            string
 }
 
@@ -74,7 +74,7 @@ func (ats *anpTunnelServer) Run() error {
 			UDSSockFile: ats.interceptorServerUDSFile,
 			TLSConfig:   ats.tlsCfg,
 		},
-		ats.initializer,
+		ats.wrappers,
 	)
 	if err != nil {
 		return fmt.Errorf("fail to wrap handler: %v", err)

--- a/pkg/yurttunnel/server/cmd.go
+++ b/pkg/yurttunnel/server/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alibaba/openyurt/pkg/projectinfo"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/constants"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
+	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/wraphandler"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/iptables"
 	kubeutil "github.com/alibaba/openyurt/pkg/yurttunnel/kubernetes"
 	"github.com/alibaba/openyurt/pkg/yurttunnel/pki"
@@ -218,8 +219,12 @@ func (o *YurttunnelServerOptions) run(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	// 5. create middleware initializer
+	// 5. create handler wrappers
 	mInitializer := initializer.NewMiddlewareInitializer(o.sharedInformerFactory)
+	wrappers, err := wraphandler.InitHandlerWrappers(mInitializer)
+	if err != nil {
+		return err
+	}
 
 	// 6. start the server
 	ts := NewTunnelServer(
@@ -230,7 +235,7 @@ func (o *YurttunnelServerOptions) run(stopCh <-chan struct{}) error {
 		o.serverAgentAddr,
 		o.serverCount,
 		tlsCfg,
-		mInitializer,
+		wrappers,
 		o.proxyStrategy)
 	if err := ts.Run(); err != nil {
 		return err

--- a/pkg/yurttunnel/server/server.go
+++ b/pkg/yurttunnel/server/server.go
@@ -19,7 +19,7 @@ package server
 import (
 	"crypto/tls"
 
-	"github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper/initializer"
+	hw "github.com/alibaba/openyurt/pkg/yurttunnel/handlerwrapper"
 )
 
 // TunnelServermanages tunnels between itself and agents, receives requests
@@ -37,7 +37,7 @@ func NewTunnelServer(
 	serverAgentAddr string,
 	serverCount int,
 	tlsCfg *tls.Config,
-	initializer initializer.MiddlewareInitializer,
+	wrappers hw.HandlerWrappers,
 	proxyStrategy string) TunnelServer {
 	ats := anpTunnelServer{
 		egressSelectorEnabled:    egressSelectorEnabled,
@@ -47,7 +47,7 @@ func NewTunnelServer(
 		serverAgentAddr:          serverAgentAddr,
 		serverCount:              serverCount,
 		tlsCfg:                   tlsCfg,
-		initializer:              initializer,
+		wrappers:                 wrappers,
 		proxyStrategy:            proxyStrategy,
 	}
 	return &ats


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
take the handler wrappers creation out of new tunnel server. because handler wrappers are not part of tunnel server, it is only used by tunnel server. so we need to prepare handler wrappers before new tunnel server.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

### III. Describe how to verify it
make test
make build
run tunnel server and check tracereq middleware is registered in handler.

### Ⅳ. Special notes for reviews


