### PR TITLE
refactor: reduce the duplication of syncing iptables setting

### DIFF
--- a/pkg/yurttunnel/server/cmd.go
+++ b/pkg/yurttunnel/server/cmd.go
@@ -175,6 +175,7 @@ func (o *YurttunnelServerOptions) run(stopCh <-chan struct{}) error {
 		iptablesMgr := iptables.NewIptablesManager(o.clientset,
 			o.sharedInformerFactory,
 			o.bindAddr,
+			o.insecureBindAddr,
 			o.iptablesSyncPeriod,
 			stopCh)
 		if iptablesMgr == nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
take the sync iptables process as a function(`func syncIptablesSetting()`), so delete the duplicated code.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make build
make test
and verify the iptables rule generated by tunnel server are correct.


### Ⅴ. Special notes for reviews


