### PR TITLE
Fix: add list and watch authority of pods, nodes, leases and daemonsets for yurt-controller-manager

### DIFF
--- a/pkg/yurtctl/constants/constants.go
+++ b/pkg/yurtctl/constants/constants.go
@@ -56,6 +56,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -76,6 +77,7 @@ rules:
   verbs:
   - delete
   - list
+  - watch
 - apiGroups:
   - ""
   - events.k8s.io
@@ -95,6 +97,16 @@ rules:
   - get
   - patch
   - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - list
+  - watch
 `
 	YurtControllerManagerClusterRoleBinding = `
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fix: add list and watch authority of pods, nodes, leases and daemonsets for yurt-controller-manager
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
(1)add watch authority of nodes for yurt-controller-manager
(2)add watch authority of events for yurt-controller-manager
(3)add list/watch authority of leases for  yurt-controller-manager
(4)add list/watch authority of daemonsets for yurt-controller-manager

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE
yurt-controller-manager  reports an error of insufficient authority, when it's running. 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

make test
make build
_output/bin/yurtctl convert --provider [minikube|ack]


### Ⅴ. Special notes for reviews


