### PR TITLE
add make commands for yurt app amanger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,33 @@ clean:
 	-rm -Rf dockerbuild
 
 e2e: 
-	hack/make-rules/build-e2e.sh
+	hack/make-rules/build-e2e.sh 
+
+
+# Generate manifests e.g. CRD, RBAC etc.
+gen-app-manager-manifests: app-manager-controller-gen
+	$(CONTROLLER_GEN) crd:trivialVersions=true rbac:roleName=manager-role webhook paths="./pkg/yurtappmanager/..." output:crd:artifacts:config=config/yurt-app-manager/crd/bases  output:rbac:artifacts:config=config/yurt-app-manager/rbac output:webhook:artifacts:config=config/yurt-app-manager/webhook
+
+# Generate code
+gen-app-manager-client: app-manager-controller-gen
+	hack/make-rules/generate_client.sh
+	$(CONTROLLER_GEN) object:headerFile="./pkg/yurtappmanager/hack/boilerplate.go.txt" paths="./pkg/yurtappmanager/apis/..."
+
+# find or download controller-gen
+# download controller-gen if necessary
+app-manager-controller-gen:
+ifeq (, $(shell which controller-gen-openyurt))
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	echo "replace sigs.k8s.io/controller-tools => github.com/openkruise/controller-tools v0.2.9-kruise" >> go.mod ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.9 ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	mv $(GOPATH)/bin/controller-gen $(GOPATH)/bin/controller-gen-openyurt ;\
+	}
+CONTROLLER_GEN=$(GOPATH)/bin/controller-gen-openyurt
+else
+CONTROLLER_GEN=$(shell which controller-gen-openyurt)
+endif

--- a/config/yurt-app-manager/certmanager/certificate.yaml
+++ b/config/yurt-app-manager/certmanager/certificate.yaml
@@ -1,0 +1,26 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
+# breaking changes
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/yurt-app-manager/certmanager/kustomization.yaml
+++ b/config/yurt-app-manager/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/yurt-app-manager/certmanager/kustomizeconfig.yaml
+++ b/config/yurt-app-manager/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/config/yurt-app-manager/crd/bases/apps.openyurt.io_nodepools.yaml
+++ b/config/yurt-app-manager/crd/bases/apps.openyurt.io_nodepools.yaml
@@ -1,0 +1,153 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: nodepools.apps.openyurt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.type
+    description: The type of nodepool
+    name: Type
+    type: string
+  - JSONPath: .status.readyNodeNum
+    description: The number of ready nodes in the pool
+    name: ReadyNodes
+    type: integer
+  - JSONPath: .status.unreadyNodeNum
+    name: NotReadyNodes
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: apps.openyurt.io
+  names:
+    categories:
+    - all
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    shortNames:
+    - np
+    singular: nodepool
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NodePool is the Schema for the nodepools API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NodePoolSpec defines the desired state of NodePool
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'If specified, the Annotations will be added to all nodes.
+                NOTE: existing labels with samy keys on the nodes will be overwritten.'
+              type: object
+            labels:
+              additionalProperties:
+                type: string
+              description: 'If specified, the Labels will be added to all nodes. NOTE:
+                existing labels with samy keys on the nodes will be overwritten.'
+              type: object
+            selector:
+              description: A label query over nodes to consider for adding to the
+                pool
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            taints:
+              description: If specified, the Taints will be added to all nodes.
+              items:
+                description: The node this Taint is attached to has the "effect" on
+                  any pod that does not tolerate the Taint.
+                type: object
+              type: array
+            type:
+              description: The type of the NodePool
+              type: string
+          type: object
+        status:
+          description: NodePoolStatus defines the observed state of NodePool
+          properties:
+            nodes:
+              description: The list of nodes' names in the pool
+              items:
+                type: string
+              type: array
+            readyNodeNum:
+              description: Total number of ready nodes in the pool.
+              format: int32
+              type: integer
+            unreadyNodeNum:
+              description: Total number of unready nodes in the pool.
+              format: int32
+              type: integer
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/yurt-app-manager/crd/bases/apps.openyurt.io_uniteddeployments.yaml
+++ b/config/yurt-app-manager/crd/bases/apps.openyurt.io_uniteddeployments.yaml
@@ -1,0 +1,259 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: uniteddeployments.apps.openyurt.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.readyReplicas
+    description: The number of pods ready.
+    name: READY
+    type: integer
+  - JSONPath: .status.templateType
+    description: The WorkloadTemplate Type.
+    name: WorkloadTemplate
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: AGE
+    type: date
+  group: apps.openyurt.io
+  names:
+    kind: UnitedDeployment
+    listKind: UnitedDeploymentList
+    plural: uniteddeployments
+    shortNames:
+    - ud
+    singular: uniteddeployment
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: UnitedDeployment is the Schema for the uniteddeployments API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: UnitedDeploymentSpec defines the desired state of UnitedDeployment.
+          properties:
+            revisionHistoryLimit:
+              description: Indicates the number of histories to be conserved. If unspecified,
+                defaults to 10.
+              format: int32
+              type: integer
+            selector:
+              description: Selector is a label query over pods that should match the
+                replica count. It must match the pod template's labels.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            topology:
+              description: Topology describes the pods distribution detail between
+                each of pools.
+              properties:
+                pools:
+                  description: Contains the details of each pool. Each element in
+                    this array represents one pool which will be provisioned and managed
+                    by UnitedDeployment.
+                  items:
+                    description: Pool defines the detail of a pool.
+                    properties:
+                      name:
+                        description: Indicates pool name as a DNS_LABEL, which will
+                          be used to generate pool workload name prefix in the format
+                          '<deployment-name>-<pool-name>-'. Name should be unique
+                          between all of the pools under one UnitedDeployment. Name
+                          is NodePool Name
+                        type: string
+                      nodeSelectorTerm:
+                        description: Indicates the node selector to form the pool.
+                          Depending on the node selector, pods provisioned could be
+                          distributed across multiple groups of nodes. A pool's nodeSelectorTerm
+                          is not allowed to be updated.
+                        type: object
+                      replicas:
+                        description: Indicates the number of the pod to be created
+                          under this pool.
+                        format: int32
+                        type: integer
+                      tolerations:
+                        description: Indicates the tolerations the pods under this
+                          pool have. A pool's tolerations is not allowed to be updated.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          type: object
+                        type: array
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            workloadTemplate:
+              description: WorkloadTemplate describes the pool that will be created.
+              properties:
+                deploymentTemplate:
+                  description: Deployment template
+                  properties:
+                    metadata:
+                      type: object
+                    spec:
+                      description: DeploymentSpec is the specification of the desired
+                        behavior of the Deployment.
+                      type: object
+                  required:
+                  - spec
+                  type: object
+                statefulSetTemplate:
+                  description: StatefulSet template
+                  properties:
+                    metadata:
+                      type: object
+                    spec:
+                      description: A StatefulSetSpec is the specification of a StatefulSet.
+                      type: object
+                  required:
+                  - spec
+                  type: object
+              type: object
+          required:
+          - selector
+          type: object
+        status:
+          description: UnitedDeploymentStatus defines the observed state of UnitedDeployment.
+          properties:
+            collisionCount:
+              description: Count of hash collisions for the UnitedDeployment. The
+                UnitedDeployment controller uses this field as a collision avoidance
+                mechanism when it needs to create the name for the newest ControllerRevision.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a UnitedDeployment's
+                current state.
+              items:
+                description: UnitedDeploymentCondition describes current state of
+                  a UnitedDeployment.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of in place set condition.
+                    type: string
+                type: object
+              type: array
+            currentRevision:
+              description: CurrentRevision, if not empty, indicates the current version
+                of the UnitedDeployment.
+              type: string
+            observedGeneration:
+              description: ObservedGeneration is the most recent generation observed
+                for this UnitedDeployment. It corresponds to the UnitedDeployment's
+                generation, which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            poolReplicas:
+              additionalProperties:
+                format: int32
+                type: integer
+              description: Records the topology detail information of the replicas
+                of each pool.
+              type: object
+            readyReplicas:
+              description: The number of ready replicas.
+              format: int32
+              type: integer
+            replicas:
+              description: Replicas is the most recently observed number of replicas.
+              format: int32
+              type: integer
+            templateType:
+              description: TemplateType indicates the type of PoolTemplate
+              type: string
+          required:
+          - currentRevision
+          - replicas
+          - templateType
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/yurt-app-manager/crd/kustomization.yaml
+++ b/config/yurt-app-manager/crd/kustomization.yaml
@@ -1,0 +1,37 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/apps.openyurt.io_uniteddeployments.yaml
+- bases/apps.openyurt.io_nodepools.yaml
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_clonesets.yaml
+#- patches/webhook_in_broadcastjobs.yaml
+#- patches/webhook_in_sidecarsets.yaml
+#- patches/webhook_in_statefulsets.yaml
+#- patches/webhook_in_uniteddeployments.yaml
+#- patches/webhook_in_daemonsets.yaml
+#- patches/webhook_in_nodeimages.yaml
+#- patches/webhook_in_imagepulljobs.yaml
+#- patches/webhook_in_nodepools.yaml
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_clonesets.yaml
+#- patches/cainjection_in_broadcastjobs.yaml
+#- patches/cainjection_in_sidecarsets.yaml
+#- patches/cainjection_in_statefulsets.yaml
+#- patches/cainjection_in_uniteddeployments.yaml
+#- patches/cainjection_in_daemonsets.yaml
+#- patches/cainjection_in_nodeimages.yaml
+#- patches/cainjection_in_imagepulljobs.yaml
+#- patches/cainjection_in_nodepools.yaml
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/config/yurt-app-manager/crd/kustomizeconfig.yaml
+++ b/config/yurt-app-manager/crd/kustomizeconfig.yaml
@@ -1,0 +1,17 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhookClientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhookClientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations

--- a/config/yurt-app-manager/crd/patches/cainjection_in_nodepools.yaml
+++ b/config/yurt-app-manager/crd/patches/cainjection_in_nodepools.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: nodepools.apps.openyurt.io

--- a/config/yurt-app-manager/crd/patches/cainjection_in_uniteddeployments.yaml
+++ b/config/yurt-app-manager/crd/patches/cainjection_in_uniteddeployments.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: uniteddeployments.apps.openyurt.io

--- a/config/yurt-app-manager/crd/patches/webhook_in_nodepools.yaml
+++ b/config/yurt-app-manager/crd/patches/webhook_in_nodepools.yaml
@@ -1,0 +1,17 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nodepools.apps.openyurt.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+      caBundle: Cg==
+      service:
+        namespace: system
+        name: webhook-service
+        path: /convert

--- a/config/yurt-app-manager/crd/patches/webhook_in_uniteddeployments.yaml
+++ b/config/yurt-app-manager/crd/patches/webhook_in_uniteddeployments.yaml
@@ -1,0 +1,17 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: uniteddeployments.apps.openyurt.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+      caBundle: Cg==
+      service:
+        namespace: system
+        name: webhook-service
+        path: /convert

--- a/config/yurt-app-manager/default/kustomization.yaml
+++ b/config/yurt-app-manager/default/kustomization.yaml
@@ -1,0 +1,70 @@
+# Adds namespace to all resources.
+namespace: kube-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: yurtapp-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# crd/kustomization.yaml
+- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+#- ../prometheus
+
+patchesStrategicMerge:
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+# - manager_auth_proxy_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# crd/kustomization.yaml
+- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/yurt-app-manager/default/manager_auth_proxy_patch.yaml
+++ b/config/yurt-app-manager/default/manager_auth_proxy_patch.yaml
@@ -1,0 +1,25 @@
+# This patch inject a sidecar container which is a HTTP proxy for the 
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"

--- a/config/yurt-app-manager/default/manager_webhook_patch.yaml
+++ b/config/yurt-app-manager/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: yurtapp-webhook-certs

--- a/config/yurt-app-manager/default/webhookcainjection_patch.yaml
+++ b/config/yurt-app-manager/default/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/yurt-app-manager/manager/kustomization.yaml
+++ b/config/yurt-app-manager/manager/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: registry.cn-hangzhou.aliyuncs.com/edge-kubernetes/yurt-app-manager
+  newTag: test-e0768f3
+patchesStrategicMerge:
+- patches.yaml

--- a/config/yurt-app-manager/manager/manager.yaml
+++ b/config/yurt-app-manager/manager/manager.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      tolerations:
+      nodeSelector:
+      containers:
+      - command:
+        - /usr/local/bin/yurt-app-manager
+        args:
+        - --enable-leader-election
+        - --v=5
+        image: controller:latest
+        imagePullPolicy: Always 
+        name: manager
+      terminationGracePeriodSeconds: 10

--- a/config/yurt-app-manager/manager/patches.yaml
+++ b/config/yurt-app-manager/manager/patches.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+

--- a/config/yurt-app-manager/prometheus/kustomization.yaml
+++ b/config/yurt-app-manager/prometheus/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- monitor.yaml

--- a/config/yurt-app-manager/prometheus/monitor.yaml
+++ b/config/yurt-app-manager/prometheus/monitor.yaml
@@ -1,0 +1,16 @@
+
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/config/yurt-app-manager/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/yurt-app-manager/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/config/yurt-app-manager/rbac/auth_proxy_role.yaml
+++ b/config/yurt-app-manager/rbac/auth_proxy_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/config/yurt-app-manager/rbac/auth_proxy_role_binding.yaml
+++ b/config/yurt-app-manager/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/yurt-app-manager/rbac/auth_proxy_service.yaml
+++ b/config/yurt-app-manager/rbac/auth_proxy_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/config/yurt-app-manager/rbac/kustomization.yaml
+++ b/config/yurt-app-manager/rbac/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/config/yurt-app-manager/rbac/leader_election_role.yaml
+++ b/config/yurt-app-manager/rbac/leader_election_role.yaml
@@ -1,0 +1,32 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/config/yurt-app-manager/rbac/leader_election_role_binding.yaml
+++ b/config/yurt-app-manager/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/yurt-app-manager/rbac/nodepool_editor_role.yaml
+++ b/config/yurt-app-manager/rbac/nodepool_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit nodepools.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nodepool-editor-role
+rules:
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools/status
+  verbs:
+  - get

--- a/config/yurt-app-manager/rbac/nodepool_viewer_role.yaml
+++ b/config/yurt-app-manager/rbac/nodepool_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view nodepools.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nodepool-viewer-role
+rules:
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools/status
+  verbs:
+  - get

--- a/config/yurt-app-manager/rbac/role.yaml
+++ b/config/yurt-app-manager/rbac/role.yaml
@@ -1,0 +1,182 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - nodepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/yurt-app-manager/rbac/role_binding.yaml
+++ b/config/yurt-app-manager/rbac/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/yurt-app-manager/rbac/uniteddeployment_editor_role.yaml
+++ b/config/yurt-app-manager/rbac/uniteddeployment_editor_role.yaml
@@ -1,0 +1,24 @@
+# permissions for end users to edit uniteddeployments.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: uniteddeployment-editor-role
+rules:
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments/status
+  verbs:
+  - get

--- a/config/yurt-app-manager/rbac/uniteddeployment_viewer_role.yaml
+++ b/config/yurt-app-manager/rbac/uniteddeployment_viewer_role.yaml
@@ -1,0 +1,20 @@
+# permissions for end users to view uniteddeployments.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: uniteddeployment-viewer-role
+rules:
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps.openyurt.io
+  resources:
+  - uniteddeployments/status
+  verbs:
+  - get

--- a/config/yurt-app-manager/samples/nodepool/apps_v1alpha1_nodepool_cloud.yaml
+++ b/config/yurt-app-manager/samples/nodepool/apps_v1alpha1_nodepool_cloud.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps.openyurt.io/v1alpha1
+kind: NodePool
+metadata:
+  name: beijing 
+spec:
+  type: Cloud 

--- a/config/yurt-app-manager/samples/nodepool/apps_v1alpha1_nodepool_edge.yaml
+++ b/config/yurt-app-manager/samples/nodepool/apps_v1alpha1_nodepool_edge.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps.openyurt.io/v1alpha1
+kind: NodePool
+metadata:
+  name: hangzhou 
+spec:
+  type: Edge 
+  annotations:
+    test.openyurt.io: test-hangzhou 
+  labels:
+    test.openyurt.io: test-hangzhou 
+  taints:
+  - key: test.openyurt.io
+    value: test-hangzhou 
+    effect: NoSchedule

--- a/config/yurt-app-manager/samples/uniteddeployment/uniteddeployment_deployment.yaml
+++ b/config/yurt-app-manager/samples/uniteddeployment/uniteddeployment_deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps.openyurt.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: ud-deployment
+spec:
+  selector:
+    matchLabels:
+      app: ud-deployment
+  workloadTemplate:
+    deploymentTemplate:
+      metadata:
+        labels:
+          app: ud-deployment
+      spec:
+        template:
+          metadata:
+            labels:
+              app: ud-deployment
+          spec:
+            containers:
+              - name: nginx
+                image: nginx:1.19.3
+  topology:
+    pools:
+    - name: cloud 
+      nodeSelectorTerm:
+        matchExpressions:
+        - key: openyurt.io/uniteddeployment
+          operator: In
+          values:
+          - cloud 
+      replicas: 2 
+    - name: edge 
+      nodeSelectorTerm:
+        matchExpressions:
+        - key: openyurt.io/uniteddeployment
+          operator: In
+          values:
+          - edge 
+      replicas: 1
+      tolerations:
+      - effect: NoSchedule
+        key: openyurt.io/taints
+        operator: Exists
+  revisionHistoryLimit: 5 

--- a/config/yurt-app-manager/samples/uniteddeployment/uniteddeployment_statefulset.yaml
+++ b/config/yurt-app-manager/samples/uniteddeployment/uniteddeployment_statefulset.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps.openyurt.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: ud-statefulset
+spec:
+  revisionHistoryLimit: 5 
+  selector:
+    matchLabels:
+      app: ud-statefulset
+  workloadTemplate:
+    statefulSetTemplate:
+      metadata:
+        labels:
+          app: ud-statefulset
+      spec:
+        template:
+          metadata:
+            labels:
+              app: ud-statefulset
+          spec:
+            containers:
+              - name: nginx
+                image: nginx:1.19.3
+  topology:
+    pools:
+    - name: cloud
+      nodeSelectorTerm:
+        matchExpressions:
+        - key: openyurt.io/uniteddeployment
+          operator: In
+          values:
+          - cloud
+      replicas: 2
+    - name: edge
+      nodeSelectorTerm:
+        matchExpressions:
+        - key: openyurt.io/uniteddeployment
+          operator: In
+          values:
+          - edge
+      replicas: 1
+      tolerations:
+      - effect: NoSchedule
+        key: openyurt.io/taints
+        operator: Exists

--- a/config/yurt-app-manager/webhook/kustomization.yaml
+++ b/config/yurt-app-manager/webhook/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- manifests.yaml
+- service.yaml
+- secret.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/yurt-app-manager/webhook/kustomizeconfig.yaml
+++ b/config/yurt-app-manager/webhook/kustomizeconfig.yaml
@@ -1,0 +1,25 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/yurt-app-manager/webhook/manifests.yaml
+++ b/config/yurt-app-manager/webhook/manifests.yaml
@@ -1,0 +1,89 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-apps-openyurt-io-v1alpha1-nodepool
+  failurePolicy: Fail
+  name: mnodepool.kb.io
+  rules:
+  - apiGroups:
+    - apps.openyurt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nodepools
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-apps-openyurt-io-v1alpha1-uniteddeployment
+  failurePolicy: Fail
+  name: muniteddeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps.openyurt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - uniteddeployments
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-openyurt-io-v1alpha1-nodepool
+  failurePolicy: Fail
+  name: vnodepool.kb.io
+  rules:
+  - apiGroups:
+    - apps.openyurt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - nodepools
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-openyurt-io-v1alpha1-uniteddeployment
+  failurePolicy: Fail
+  name: vuniteddeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps.openyurt.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - uniteddeployments

--- a/config/yurt-app-manager/webhook/secret.yaml
+++ b/config/yurt-app-manager/webhook/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: kube-system

--- a/config/yurt-app-manager/webhook/service.yaml
+++ b/config/yurt-app-manager/webhook/service.yaml
@@ -1,0 +1,12 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9876 
+  selector:
+    control-plane: controller-manager

--- a/hack/lib/build.sh
+++ b/hack/lib/build.sh
@@ -22,6 +22,7 @@ readonly YURT_ALL_TARGETS=(
     yurt-controller-manager
     yurt-tunnel-server
     yurt-tunnel-agent
+    yurt-app-manager
 )
 
 # we will generates setup yaml files for following components
@@ -30,6 +31,7 @@ readonly YURT_YAML_TARGETS=(
     yurt-controller-manager
     yurt-tunnel-server
     yurt-tunnel-agent
+    yurt-app-manager
 )
 
 #PROJECT_PREFIX=${PROJECT_PREFIX:-yurt}
@@ -122,6 +124,10 @@ gen_yamls() {
     local yaml_dir=$YURT_OUTPUT_DIR/setup/
     mkdir -p $yaml_dir
     for yaml_target in "${yaml_targets[@]}"; do
+        if [ "$yaml_target" == "yurt-app-manager" ]; then
+            gen_yurtappmanager_yaml 
+            continue
+        fi 
         oup_file=${yaml_target/yurt/$PROJECT_PREFIX}
         echo "generating yaml file for $oup_file"
         sed "s|__project_prefix__|${PROJECT_PREFIX}|g;
@@ -133,4 +139,11 @@ gen_yamls() {
             $YURT_ROOT/config/yaml-template/$yaml_target.yaml > \
             $yaml_dir/$oup_file.yaml
     done
+}
+
+gen_yurtappmanager_yaml() {
+    set +x
+    echo "==== yurt app manager yaml ===="
+    echo ""
+    kustomize build $YURT_ROOT/config/yurt-app-manager/default
 }

--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -29,6 +29,7 @@ readonly -a YURT_BIN_TARGETS=(
     yurtctl-servant
     yurt-tunnel-server
     yurt-tunnel-agent
+    yurt-app-manager
 )
 
 readonly -a SUPPORTED_ARCH=(

--- a/hack/make-rules/generate_client.sh
+++ b/hack/make-rules/generate_client.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+YURT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+TMP_DIR=$(mktemp -d)
+mkdir -p "${TMP_DIR}"/src/github.com/alibaba/openyurt/pkg/yurtappmanager/client
+cp -r ${YURT_ROOT}/{go.mod,go.sum} "${TMP_DIR}"/src/github.com/alibaba/openyurt/
+cp -r ${YURT_ROOT}/pkg/yurtappmanager/{apis,hack} "${TMP_DIR}"/src/github.com/alibaba/openyurt/pkg/yurtappmanager/
+
+(
+  cd "${TMP_DIR}"/src/github.com/alibaba/openyurt/;
+  HOLD_GO="${TMP_DIR}/src/github.com/alibaba/openyurt/pkg/yurtappmanager/hack/hold.go"
+  printf 'package hack\nimport "k8s.io/code-generator"\n' > ${HOLD_GO}
+  go mod vendor
+  GOPATH=${TMP_DIR} GO111MODULE=off /bin/bash vendor/k8s.io/code-generator/generate-groups.sh all \
+    github.com/alibaba/openyurt/pkg/yurtappmanager/client github.com/alibaba/openyurt/pkg/yurtappmanager/apis apps:v1alpha1 -h ./pkg/yurtappmanager/hack/boilerplate.go.txt
+)
+
+rm -rf ./pkg/yurtappmanager/client/{clientset,informers,listers}
+mv "${TMP_DIR}"/src/github.com/alibaba/openyurt/pkg/yurtappmanager/client/* ./pkg/yurtappmanager/client
+

--- a/pkg/yurtappmanager/hack/boilerplate.go.txt
+++ b/pkg/yurtappmanager/hack/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/pkg/yurtappmanager/hack/doc.go
+++ b/pkg/yurtappmanager/hack/doc.go
@@ -1,0 +1,1 @@
+package hack


### PR DESCRIPTION
Signed-off-by: kadisi <iamkadisi@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does

ref #171 

add make commands for yurt-app-manager:

- make build 
Build yurt-app-manger binaries
`make build WHAT=cmd/yurt-app-manager ARCH=amd64`
- make release
Build yurt-app-manger image
`make release WHAT=cmd/yurt-app-manager ARCH=amd64`
- make gen-yaml
Build yurt-app-manger yaml
`make gen-yaml WHAT=yurt-app-manager`
- make gen-app-manager-manifests
Generate yurt-app-manager manifests e.g. CRD, RBAC etc
`make gen-app-manager-manifests`
- make gen-app-manager-client
Generate yurt-app-manger client code
`make gen-app-manager-client`


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

The files under ` config/yurt-app-manager` dir are mainly generated by `kubebuild` and `controller-gen` command.
The files under `pkg/yurtappmanager/client` dir are mainly generated by `make gen-app-manager-client` command.
 
Please review these documents in detail：

Makefile
hack/lib/build.sh
hack/lib/release-images.sh

@Fei-Guo @charleszheng44 



