### PR TITLE
refactor the  template of  yurt-tunnel

### DIFF
--- a/config/setup/yurt-tunnel-agent.yaml
+++ b/config/setup/yurt-tunnel-agent.yaml
@@ -52,7 +52,6 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
         openyurt.io/edge-enable-reverseTunnel-client: "true"
       containers:
@@ -61,13 +60,15 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         image: openyurt/yurt-tunnel-agent:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: yurt-tunnel-agent
         volumeMounts:
         - name: k8s-dir
           mountPath: /etc/kubernetes
         - name: kubelet-pki
           mountPath: /var/lib/kubelet/pki
+        - name: tunnel-agent-dir
+          mountPath: /var/lib/yurt-tunnel-agent
         env:
         - name: NODE_NAME
           valueFrom:
@@ -88,3 +89,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pki
           type: Directory
+      - name: tunnel-agent-dir
+        hostPath:
+          path: /var/lib/yurt-tunnel-agent
+          type: DirectoryOrCreate

--- a/config/setup/yurt-tunnel-server.yaml
+++ b/config/setup/yurt-tunnel-server.yaml
@@ -108,6 +108,11 @@ spec:
       hostNetwork: true
       serviceAccountName: yurt-tunnel-server
       restartPolicy: Always
+      volumes:
+      - name: tunnel-server-dir
+        hostPath:
+          path: /var/lib/edge-tunnel-server
+          type: DirectoryOrCreate
       tolerations:
       - key: "node-role.alibabacloud.com/addon"
         operator: "Exists"
@@ -132,3 +137,6 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
+        volumeMounts:
+        - name: tunnel-server-dir
+          mountPath: /var/lib/edge-tunnel-server

--- a/config/yaml-template/yurt-tunnel-agent.yaml
+++ b/config/yaml-template/yurt-tunnel-agent.yaml
@@ -52,7 +52,6 @@ spec:
         k8s-app: __project_prefix__-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
         __label_prefix__/edge-enable-reverseTunnel-client: "true"
       containers:
@@ -61,13 +60,15 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         image: __repo__/__project_prefix__-tunnel-agent:__tag__
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: __project_prefix__-tunnel-agent
         volumeMounts:
         - name: k8s-dir
           mountPath: /etc/kubernetes
         - name: kubelet-pki
           mountPath: /var/lib/kubelet/pki
+        - name: tunnel-agent-dir
+          mountPath: /var/lib/yurt-tunnel-agent
         env:
         - name: NODE_NAME
           valueFrom:
@@ -88,3 +89,7 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pki
           type: Directory
+      - name: tunnel-agent-dir
+        hostPath:
+          path: /var/lib/yurt-tunnel-agent
+          type: DirectoryOrCreate

--- a/config/yaml-template/yurt-tunnel-server.yaml
+++ b/config/yaml-template/yurt-tunnel-server.yaml
@@ -108,6 +108,11 @@ spec:
       hostNetwork: true
       serviceAccountName: __project_prefix__-tunnel-server
       restartPolicy: Always
+      volumes:
+      - name: tunnel-server-dir
+        hostPath:
+          path: /var/lib/edge-tunnel-server
+          type: DirectoryOrCreate
       tolerations:
       - key: "node-role.alibabacloud.com/addon"
         operator: "Exists"
@@ -132,3 +137,6 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
+        volumeMounts:
+        - name: tunnel-server-dir
+          mountPath: /var/lib/edge-tunnel-server

--- a/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-agent-tmpl.go
@@ -74,7 +74,6 @@ spec:
         k8s-app: yurt-tunnel-agent
     spec:
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
         beta.kubernetes.io/os: linux
         {{.edgeWorkerLabel}}: "true"
       containers:
@@ -83,13 +82,15 @@ spec:
         args:
         - --node-name=$(NODE_NAME)
         image: {{.image}}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: yurt-tunnel-agent
         volumeMounts:
         - name: k8s-dir
           mountPath: /etc/kubernetes
         - name: kubelet-pki
           mountPath: /var/lib/kubelet/pki
+        - name: tunnel-agent-dir
+          mountPath: /var/lib/yurt-tunnel-agent
         env:
         - name: NODE_NAME
           valueFrom:
@@ -110,5 +111,9 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pki
           type: Directory
+      - name: tunnel-agent-dir
+        hostPath:
+          path: /var/lib/yurt-tunnel-agent
+          type: DirectoryOrCreate
 `
 )

--- a/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
+++ b/pkg/yurtctl/constants/yurt-tunnel-server-tmpl.go
@@ -133,6 +133,11 @@ spec:
       hostNetwork: true
       serviceAccountName: yurt-tunnel-server
       restartPolicy: Always
+      volumes:
+      - name: tunnel-server-dir
+        hostPath:
+          path: /var/lib/edge-tunnel-server
+          type: DirectoryOrCreate
       tolerations:
       - key: "node-role.alibabacloud.com/addon"
         operator: "Exists"
@@ -158,5 +163,8 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
+        volumeMounts:
+        - name: tunnel-server-dir
+          mountPath: /var/lib/edge-tunnel-server
 `
 )


### PR DESCRIPTION
refactor the template of yurt-tunnel.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
(1) delete nodeselector beta.kubernetes.io/os=amd64
(2) modify imagePullPolicy to IfNotPresent
(3)add volume tunnel-agent-dir/tunnel-server-dir

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No issue, the reason for the modification is as follows:
(1) yurt-tunnel-agent need support multiple cpu arch, include arm, arm64 and amd64.
(2) If the imagePullPolicy is always, the corresponding pod cann't be restarted when the edge node is disconnected.
(3) yurt-tunnel will use dir /var/lib/yurthub deposit certificate.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

make test
make build
_output/bin/yurtctl convert --provider [minikube|ack|kubeadm]

### Ⅴ. Special notes for reviews


