### PR TITLE
Delete clusterrolebinding system:controller:node-controller to disable node-controller.

### DIFF
--- a/pkg/yurtctl/cmd/convert/convert.go
+++ b/pkg/yurtctl/cmd/convert/convert.go
@@ -264,12 +264,11 @@ func (co *ConvertOptions) RunConvert() (err error) {
 		return
 	}
 
-	// 4. delete the node-controller service account to disable node-controller
-	if err = co.clientSet.CoreV1().ServiceAccounts("kube-system").
-		Delete("node-controller", &metav1.DeleteOptions{
-			PropagationPolicy: &kubeutil.PropagationPolicy,
-		}); err != nil && !apierrors.IsNotFound(err) {
-		klog.Errorf("fail to delete ServiceAccount(node-controller): %s", err)
+	// 4. delete the system:controller:node-controller clusterrolebinding to disable node-controller
+	if err = co.clientSet.RbacV1().ClusterRoleBindings().Delete("system:controller:node-controller", &metav1.DeleteOptions{
+		PropagationPolicy: &kubeutil.PropagationPolicy,
+	}); err != nil && !apierrors.IsNotFound(err) {
+		klog.Errorf("fail to delete clusterrolebinding system:controller:node-controller: %v", err)
 		return
 	}
 


### PR DESCRIPTION
Delete clusterrolebinding system:controller:node-controller to disable node-controller.
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
(1) delete clusterrolebinding system:controller:node-controller when convert to OpenYurt cluster.
(2) create clusterrolebinding system:controller:node-controller when revert to k8s cluster.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

because when revert openyurt to kubernetes, a new serviceaccount and secret need to be created, so node-controller must be restarted before new serviceaccount and secret can take effect.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make test
make build
_output/bin/yurtctl convert --provider [minikube|ack|kubeadm]

### Ⅴ. Special notes for reviews


