### PR TITLE
fix: yurtctl fail to convert minikube cluster.

### DIFF
--- a/config/yurtctl-servant/setup_edgenode
+++ b/config/yurtctl-servant/setup_edgenode
@@ -87,36 +87,14 @@ error() {
 
 check_addr()
 {
-    echo $1|grep "^\(https\|http\)\:\/\/[0-9]\{1,3\}\.\([0-9]\{1,3\}\.\)\{2\}[0-9]\{1,3\}\:[0-9]\{1,5\}$" > /dev/null;
+    echo $1|grep -E '^(http(s)?:\/\/)?[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+(:[0-9]{1,5})?$' > /dev/null;
     if [ $? -ne 0 ]
     then
         log "apiserver addr $1 is error."
         exit 1
     fi
-    addr=`echo $1 | awk -F '://' '{print $2}'`
-    ipaddr=`echo $addr | awk -F ':' '{print $1}'`
-    port=`echo $addr | awk -F ':' '{print $2}'`
 
-    echo $ipaddr, $port
-    a=`echo $ipaddr|awk -F . '{print $1}'`  #以"."分隔，取出每个列的值
-    b=`echo $ipaddr|awk -F . '{print $2}'`
-    c=`echo $ipaddr|awk -F . '{print $3}'`
-    d=`echo $ipaddr|awk -F . '{print $4}'`
-    for num in $a $b $c $d
-    do
-        if [ $num -gt 255 ] || [ $num -lt 0 ]    #每个数值必须在0-255之间
-        then
-          log "apiserver addr $1 is error."
-          exit 1
-        fi
-   done
-
-   if [ $port -ge 65536 ];then
-        log "apiserver addr $1 is error."
-        exit 1
-   fi
-
-   log apiserver addr $1 is ok.
+   log "apiserver addr $1 is ok."
    return 0
 }
 

--- a/pkg/yurtctl/util/kubernetes/util.go
+++ b/pkg/yurtctl/util/kubernetes/util.go
@@ -43,6 +43,7 @@ import (
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmcontants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	tokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 
 	"github.com/alibaba/openyurt/pkg/yurtctl/constants"
@@ -414,7 +415,7 @@ func GetOrCreateJoinTokenString(cliSet *kubernetes.Clientset) (string, error) {
 	}
 
 	klog.V(1).Infoln("[token] creating token")
-	if err := tokenphase.CreateNewTokens(cliSet, []kubeadmapi.BootstrapToken{{Token: token}}); err != nil {
+	if err := tokenphase.CreateNewTokens(cliSet, []kubeadmapi.BootstrapToken{{Token: token, Usages: kubeadmcontants.DefaultTokenUsages, Groups: kubeadmcontants.DefaultTokenGroups}}); err != nil {
 		return "", err
 	}
 	return tokenStr, nil


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
(1) support domain name for server addr.
(2)add  Usages and  Groups when creating bootstrap token.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
No issue, the reason for the modification is as follows:
(1)minikube use domain name control-plane.minikube.internal to access apiserver.
(2)bootstrap token need set  authentication,signing for  Usages and system:bootstrappers:kubeadm:default-node-token for groups.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
make test
make build
_output/bin/yurtctl convert --provider [minikube|ack|kubeadm]

### Ⅴ. Special notes for reviews


