### PR TITLE
Docs: fix `systemctl restart` in manually-setup tutorial

### DIFF
--- a/docs/tutorial/manually-setup.md
+++ b/docs/tutorial/manually-setup.md
@@ -104,5 +104,5 @@ sed -i "s|KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=\/etc\/kubernetes\/boot
 Finally, we restart the kubelet service
 ```bash
 # assume we are logged in to the edge node already 
-$ systemctl daemon-reload && systemctl restart
+$ systemctl daemon-reload && systemctl restart kubelet
 ```


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
A simple fix for manually-setup tutorial.  The command `systemctl restart` should be `systemctl restart kubelet`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


