### PR TITLE
Fix rebuild yurtctl exception

### DIFF
--- a/hack/lib/build.sh
+++ b/hack/lib/build.sh
@@ -90,7 +90,7 @@ build_binaries() {
     done
     
     if [[ $(host_platform) == ${HOST_PLATFORM} ]]; then
-      rm -f "${YURT_BIN_DIR}"
+      rm -rf "${YURT_BIN_DIR}"
       ln -s "${target_bin_dir}" "${YURT_BIN_DIR}"
     fi
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/alibaba/openyurt/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR does
When rebuild the `yurtctl` binary:
`make WHAT=cmd/yurtctl` hits exception, it said:
rm: cannot remove '/root/go/src/github.com/alibaba/openyurt/_output/bin': Is a directory

So fix it.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


